### PR TITLE
ci: add timeout for running images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       - run: git lfs checkout
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo build
       - name: Run images
+        timeout-minutes: 1
         run: |
           cargo run -- -v data/x86_64/hello_world
           cargo run -- -v benches_data/rusty_demo


### PR DESCRIPTION
Host panics may cause in Uhyve not terminating: https://github.com/hermit-os/uhyve/actions/runs/7963339605/job/21738698422