### PR TITLE
Fix Codecov git directory issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
     name: Coverage
     runs-on: [self-hosted]
     steps:
+      - name: Test
+        run: echo $HOME && cd ~ && pwd && cd -
       - name: Install gdb
         run: |
           sudo apt-get update
@@ -147,3 +149,5 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+    env:
+      HOME: "/root"


### PR DESCRIPTION
This hotfixes an issue with self-hosted git runners not exporting `$HOME`. (e.g., https://github.com/hermit-os/uhyve/actions/runs/8247074385/job/22554464362#step:8:28). In the long run, it would probably be better to containerize these jobs.