### PR TITLE
ci: pin codecov to v4.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.0.2
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/hermit-os/uhyve/pull/659.

For a proper fix, we have to wait for https://github.com/codecov/codecov-action/pull/1343.