### PR TITLE
fix(x86_64): don't panic on unknown port

### DIFF
--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -391,8 +391,8 @@ impl VirtualCPU for KvmCpu {
 							let virtio_device = self.parent_vm.virtio_device.lock().unwrap();
 							virtio_device.read_link_status(addr);
 						}
-						_ => {
-							info!("Unhanded IO Exit");
+						port => {
+							warn!("guest read from unknown I/O port {port:#x}");
 						}
 					},
 					VcpuExit::IoOut(port, addr) => {
@@ -474,8 +474,8 @@ impl VirtualCPU for KvmCpu {
 										self.parent_vm.virtio_device.lock().unwrap();
 									virtio_device.write_pfn(addr, &self.parent_vm.mem);
 								}
-								_ => {
-									panic!("Unhandled IO exit: 0x{:x}", port);
+								port => {
+									warn!("guest wrote to unknown I/O port {port:#x}");
 								}
 							}
 						}


### PR DESCRIPTION
QEMU and Firecracker don't panic here either.

With this, `hermit::arch::x86_64::shutdown` from https://github.com/hermit-os/kernel/pull/1181 would also work on Uhyve, though proper exits via system calls still go through the exit hypercall.