### PR TITLE
WIP: sysinfo: Add new frequency detection method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "core_affinity"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +799,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1288,6 +1303,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1463,7 @@ dependencies = [
  "raw-cpuid",
  "rftrace",
  "rftrace-frontend",
+ "sysinfo",
  "thiserror",
  "time",
  "tun-tap",
@@ -1615,6 +1646,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ uhyve-interface = { version = "0.1.1", path = "uhyve-interface", features = ["st
 virtio-bindings = { version = "0.2", features = ["virtio-v4_14_0"] }
 rftrace = { version = "0.1", optional = true }
 rftrace-frontend = { version = "0.1", optional = true }
+sysinfo = "0.30.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = "0.8"

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -8,6 +8,7 @@ use std::{
 
 use log::{debug, warn};
 use raw_cpuid::{CpuId, CpuIdReaderNative};
+use sysinfo::System;
 use thiserror::Error;
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 use x86_64::{
@@ -27,6 +28,29 @@ const KHZ_TO_HZ: u64 = 1000;
 #[derive(Error, Debug)]
 #[error("Frequency detection failed")]
 pub struct FrequencyDetectionFailed;
+
+pub fn detect_freq_from_sysinfo() -> std::result::Result<u32, FrequencyDetectionFailed> {
+	debug!("Trying to detect CPU frequency using sysinfo");
+
+	let mut system = System::new();
+	system.refresh_cpu_frequency();
+
+	let frequency = system.cpus().first().unwrap().frequency();
+
+	if !system.cpus().iter().all(|cpu| cpu.frequency() == frequency) {
+		// Even if the CPU frequencies are not all equal, the
+		// frequency of the "first" CPU is treated as "authoritative".
+		eprintln!("CPU frequencies are not all equal");
+	}
+
+	// TODO: What can I do with the library's insistence of using u64 whereas I have to use u32?
+	// Is try_into() enough?
+	if frequency > 0 {
+		Ok(frequency.try_into().unwrap())
+	} else {
+		Err(FrequencyDetectionFailed)
+	}
+}
 
 pub fn detect_freq_from_cpuid(
 	cpuid: &CpuId<CpuIdReaderNative>,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -18,7 +18,8 @@ use thiserror::Error;
 
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86_64::{
-	detect_freq_from_cpuid, detect_freq_from_cpuid_hypervisor_info, get_cpu_frequency_from_os,
+	detect_freq_from_cpuid, detect_freq_from_cpuid_hypervisor_info, detect_freq_from_sysinfo,
+	get_cpu_frequency_from_os,
 };
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 use crate::linux::x86_64::kvm_cpu::initialize_kvm;
@@ -44,15 +45,21 @@ pub type LoadKernelResult<T> = Result<T, LoadKernelError>;
 // TODO: move to architecture specific section
 fn detect_cpu_freq() -> u32 {
 	#[cfg(target_arch = "aarch64")]
-	let mhz: u32 = 0;
+	let mhz: u32 = detect_freq_from_sysinfo().unwrap_or_else(|_| {
+		debug!("Failed to detect using sysinfo");
+		0
+	});
 	#[cfg(target_arch = "x86_64")]
 	let mhz = {
-		let cpuid = raw_cpuid::CpuId::new();
-		let mhz: u32 = detect_freq_from_cpuid(&cpuid).unwrap_or_else(|_| {
-			debug!("Failed to detect from cpuid");
-			detect_freq_from_cpuid_hypervisor_info(&cpuid).unwrap_or_else(|_| {
-				debug!("Failed to detect from hypervisor_info");
-				get_cpu_frequency_from_os().unwrap_or(0)
+		let mhz: u32 = detect_freq_from_sysinfo().unwrap_or_else(|_| {
+			debug!("Failed to detect using sysinfo");
+			let cpuid = raw_cpuid::CpuId::new();
+			detect_freq_from_cpuid(&cpuid).unwrap_or_else(|_| {
+				debug!("Failed to detect from cpuid");
+				detect_freq_from_cpuid_hypervisor_info(&cpuid).unwrap_or_else(|_| {
+					debug!("Failed to detect from hypervisor_info");
+					get_cpu_frequency_from_os().unwrap_or(0)
+				})
 			})
 		});
 		debug!("detected a cpu frequency of {} Mhz", mhz);


### PR DESCRIPTION
This is a proof-of-concept, there is some more testing necessary and some questions as to how this feature should be implemented: https://github.com/hermit-os/uhyve/issues/690

### TODOs

- [ ] Does this work on aarch64?
  - [ ] 64-bit Raspberry Pi
  - [ ] macOS (???)
- [ ] How do we deal with sysinfo on x86_64?
- [ ] Potential conflict with https://github.com/hermit-os/uhyve/pull/688
- [ ] Remove **TODO** comments, fix formatting.
- [ ] Better design, so that we don't have to convert u64 into u32?
    
  I don't think that there's a "serious" case where it would return a zero, so this would technically turn the alternatives (e.g. CPUID) into dead code 99.99% of the time.

#### Nice-to-haves

- [ ] The `sysinfo` crate adds a new dependency on `windows` crates. Perhaps a feature upstream that would remove that dependency would be great, as Windows is not a target.


---

- Add detect_freq_from_sysinfo()

  Shows a real-time value of the base frequency, similarly to /proc/cpuinfo on Linux.

  Using sysinfo as an alternative to the CPUID-provided value may be useful for some systems where the CPUID feature is not available. A potential flaw of this implementation is that the frequency is passed once to before the initialization of the kernel and cannot be changed later.

  If the host system is in "power-saving mode" (e.g. in laptops) and then switches to "performance mode", the application will not have any knowledge of this change. IIRC, Jonathan thinks this is OK for now.

- Use sysinfo by default on x86_64 instead of CPUID.

  Currently for demonstration reasons, we may want to amend this in a later revision.

Fixes: https://github.com/hermit-os/uhyve/issues/690