### PR TITLE
CI: Publish binaries using GitHub Actions on new tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Clippy
         run: cargo clippy --all-targets ${{ matrix.flags }} -- -D warnings
-  
+
   clippy-test-kernel:
     name: Clippy test-kernels
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
       # TODO: Remove once we have a hermit toolchain upgrade
       # capable of sparse registries
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
-      
+
   coverage:
     name: Coverage
     runs-on: [self-hosted]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  release:
+    name: Create new release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            filename_suffix: "${{ github.ref_name }}-linux-amd64"
+    steps:
+      - uses: actions/checkout@v4
+      # Adapted from: https://github.com/mkroening/edu-sync/blob/main/.github/workflows/release.yml
+      - run: gh release create ${{ github.ref }} --draft --title "Uhyve ${{ github.ref_name }}"
+        if: startsWith(matrix.os, 'ubuntu')
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release --locked
+      - name: Create archive
+        run: |
+          DIST=uhyve-${{ matrix.filename_suffix }}
+          mkdir $DIST
+
+          mv target/release/uhyve $DIST
+          cp README.md $DIST
+          cp LICENSE-* $DIST
+
+          tar czf $DIST.tar.gz $DIST
+          echo "FILE=$DIST.tar.gz" >> $GITHUB_ENV
+      - run: gh release upload ${{ github.ref }} $FILE


### PR DESCRIPTION
Because of time constraints and because the workflow itself may need some additional work to support multiple operating systems without making individual releases for every target architecture and operating system, builds are only generated for Linux (amd64).

New releases are marked as "Drafts" by default, so as to allow maintainers to edit the text before publication.

Fixes https://github.com/hermit-os/uhyve/issues/256