### PR TITLE
vm.rs: Replace hardcoded arch::RAM_START in BootInfo

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -201,8 +201,8 @@ impl<VCpuType: VirtualCPU> UhyveVm<VCpuType> {
 
 		let boot_info = BootInfo {
 			hardware_info: HardwareInfo {
-				phys_addr_range: arch::RAM_START.as_u64()
-					..arch::RAM_START.as_u64() + self.mem.memory_size as u64,
+				phys_addr_range: self.mem.guest_address.as_u64()
+					..self.mem.guest_address.as_u64() + self.mem.memory_size as u64,
 				serial_port_base: self.verbose().then(|| {
 					SerialPortBase::new((uhyve_interface::HypercallAddress::Uart as u16).into())
 						.unwrap()


### PR DESCRIPTION
There was an idea to initialize the mmap using different guest_address parameters.

Despite how most of the code is already "future-proofed", with a clear intention of heading towards that direction and `vm.rs` using `self.mem.guest_address` everywhere (despite that value currently being equal to zero), this change modifies a small exception to that rule.