### PR TITLE
Use descriptive variable names for addresses

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -113,11 +113,11 @@ fn is_valid_address(virtual_address: GuestVirtAddr) -> bool {
 
 /// Converts a virtual address in the guest to a physical address in the guest
 pub fn virt_to_phys(
-	addr: GuestVirtAddr,
+	guest_virt_addr: GuestVirtAddr,
 	mem: &MmapMemory,
 	pagetable_l0: GuestPhysAddr,
 ) -> Result<GuestPhysAddr, PagetableError> {
-	if !is_valid_address(addr) {
+	if !is_valid_address(guest_virt_addr) {
 		return Err(PagetableError::InvalidAddress);
 	}
 
@@ -138,8 +138,8 @@ pub fn virt_to_phys(
 	};
 	// TODO: Depending on the virtual address length and granule (defined in TCR register by TG and TxSZ), we could reduce the number of pagetable walks. Hermit doesn't do this at the moment.
 	for level in 0..3 {
-		let table_index =
-			(addr.as_u64() >> PAGE_BITS >> ((3 - level) * PAGE_MAP_BITS) & PAGE_MAP_MASK) as usize;
+		let table_index = (guest_virt_addr.as_u64() >> PAGE_BITS >> ((3 - level) * PAGE_MAP_BITS)
+			& PAGE_MAP_MASK) as usize;
 		let pte = PageTableEntry::from(pagetable[table_index]);
 		// TODO: We could stop here if we have a "Block Entry" (ARM equivalent to huge page). Currently not supported.
 
@@ -149,7 +149,7 @@ pub fn virt_to_phys(
 			)
 		};
 	}
-	let table_index = (addr.as_u64() >> PAGE_BITS & PAGE_MAP_MASK) as usize;
+	let table_index = (guest_virt_addr.as_u64() >> PAGE_BITS & PAGE_MAP_MASK) as usize;
 	let pte = PageTableEntry::from(pagetable[table_index]);
 
 	Ok(pte.address())

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -130,18 +130,17 @@ lazy_static! {
 		let cap: u64 = { read_vmx_cap(&xhypervisor::VMXCap::PINBASED).unwrap() };
 		cap2ctrl(cap, PIN_BASED_INTR | PIN_BASED_NMI | PIN_BASED_VIRTUAL_NMI)
 	};
-	static ref CAP_PROCBASED: u64 = {
-		let cap: u64 = { read_vmx_cap(&xhypervisor::VMXCap::PROCBASED).unwrap() };
-		cap2ctrl(
-			cap,
-			CPU_BASED_SECONDARY_CTLS
-				| CPU_BASED_MWAIT
-				| CPU_BASED_MSR_BITMAPS
-				| CPU_BASED_MONITOR
-				| CPU_BASED_TSC_OFFSET
-				| CPU_BASED_TPR_SHADOW,
-		)
-	};
+	static ref CAP_PROCBASED: u64 =
+		{
+			let cap: u64 = { read_vmx_cap(&xhypervisor::VMXCap::PROCBASED).unwrap() };
+			cap2ctrl(
+				cap,
+				CPU_BASED_SECONDARY_CTLS
+					| CPU_BASED_MWAIT | CPU_BASED_MSR_BITMAPS
+					| CPU_BASED_MONITOR | CPU_BASED_TSC_OFFSET
+					| CPU_BASED_TPR_SHADOW,
+			)
+		};
 	static ref CAP_PROCBASED2: u64 = {
 		let cap: u64 = { read_vmx_cap(&xhypervisor::VMXCap::PROCBASED2).unwrap() };
 		cap2ctrl(cap, CPU_BASED2_RDTSCP | CPU_BASED2_APIC_REG_VIRT)


### PR DESCRIPTION
When a function accepts a guest virtual address or a guest physical address as a parameter, use guest_virt_addr and guest_phys_addr respectively.

No functional change. Addresses of types u16, u64 and u8 were deliberately not changed, only addresses of the types GuestPhysAddr and GuestVirtAddr were affected. There is only one exception in `src/macos/aarch64/vcpu.rs` where a u16 address is immediately set to `exception.physical_address.try_into().unwrap()`.

This nitpick is meant to increase readability, as I've found myself say "wait, which type of address is this again?" during debugging and as I went back and forth reading the code.