### PR TITLE
CI: Enable RUST_BACKTRACE for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           cargo test --lib
           cargo test --bins --examples
           cargo test --doc
+    env:
+      RUST_BACKTRACE: 1
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
Could be useful in some cases when GitHub Actions fails on a specific target.