### PR TITLE
ASLR support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,9 +656,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-entry"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3489d14d0767c3d6a151e6e08effa39270356b7c6fe589775da8676a57c4d4cd"
+checksum = "c92a8deb1f5da66f858a5e86cf441575cd6ebdc60d41a6be232f0f9c8e18cecc"
 dependencies = [
  "align-address",
  "const_parse",
@@ -1500,6 +1500,7 @@ dependencies = [
 name = "uhyve"
 version = "0.4.0"
 dependencies = [
+ "align-address",
  "assert_fs",
  "bitflags 2.8.0",
  "burst",
@@ -1520,6 +1521,7 @@ dependencies = [
  "mac_address",
  "memory_addresses",
  "nix 0.29.0",
+ "rand",
  "raw-cpuid 11.3.0",
  "rftrace",
  "rftrace-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,12 @@ path = "benches/benchmarks.rs"
 harness = false
 
 [features]
-default = []
+default = ["aslr"]
+aslr = ["dep:rand"]
 instrument = ["rftrace", "rftrace-frontend"]
 
 [dependencies]
+align-address = "0.3.0"
 byte-unit = { version = "5", features = ["byte"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 nix = { version = "0.29", features = ["mman", "pthread", "signal"] }
@@ -48,7 +50,7 @@ either = "1.13"
 env_logger = "0.11"
 gdbstub = "0.7"
 gdbstub_arch = "0.3"
-hermit-entry = { version = "0.10", features = ["loader"] }
+hermit-entry = { version = "0.10.3", features = ["loader"] }
 libc = "0.2"
 log = "0.4"
 mac_address = "1.1"
@@ -59,6 +61,7 @@ uhyve-interface = { version = "0.1.1", path = "uhyve-interface", features = ["st
 virtio-bindings = { version = "0.2", features = ["virtio-v4_14_0"] }
 rftrace = { version = "0.1", optional = true }
 rftrace-frontend = { version = "0.2", optional = true }
+rand = { version = "0.8.5", optional = true }
 shell-words = "1"
 sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 vm-fdt = "0.3"

--- a/src/arch/x86_64/paging/mod.rs
+++ b/src/arch/x86_64/paging/mod.rs
@@ -1,9 +1,13 @@
+use uhyve_interface::GuestPhysAddr;
 use x86_64::{
-	structures::paging::{Page, PageTable, PageTableFlags, Size2MiB},
-	PhysAddr,
+	structures::paging::{
+		mapper::PageTableFrameMapping, FrameAllocator, MappedPageTable, Mapper, Page, PageSize,
+		PageTable, PageTableFlags, PageTableIndex, PhysFrame, Size2MiB, Size4KiB,
+	},
+	VirtAddr,
 };
 
-use crate::consts::*;
+use crate::{consts::*, paging::BumpAllocator};
 
 // Constructor for a conventional segment GDT (or LDT) entry
 pub fn create_gdt_entry(flags: u64, base: u64, limit: u64) -> u64 {
@@ -14,7 +18,28 @@ pub fn create_gdt_entry(flags: u64, base: u64, limit: u64) -> u64 {
 		| (limit & 0x0000ffffu64)
 }
 
-pub const MIN_PHYSMEM_SIZE: usize = BOOT_PDE.as_u64() as usize + 0x1000;
+unsafe impl FrameAllocator<Size4KiB> for BumpAllocator<{ Size4KiB::SIZE }> {
+	fn allocate_frame(&mut self) -> Option<x86_64::structures::paging::PhysFrame<Size4KiB>> {
+		self.allocate()
+			// Safety: pa is aligned and from a host perspective the Frame is just a number without UB.
+			.map(|pa| unsafe { PhysFrame::from_start_address_unchecked(pa.into()) })
+	}
+}
+
+/// A mapper, that does not require to be run inside the system to be mapped.
+/// Attention: This must be used in an empty or correctly mapped system with
+/// `mem` of sufficient size and `guest_address` beeing the correct guest-
+/// physical-address of `mem`. Otherwise this will corrup memory and lead to UB.
+struct UhyvePageTableFrameMapper<'a> {
+	mem: &'a mut [u8],
+	guest_address: GuestPhysAddr,
+}
+unsafe impl PageTableFrameMapping for UhyvePageTableFrameMapper<'_> {
+	fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
+		let rel_addr = frame.start_address().as_u64() - self.guest_address.as_u64();
+		unsafe { self.mem.as_ptr().add(rel_addr as usize) as *mut PageTable }
+	}
+}
 
 /// Creates the pagetables and the GDT in the guest memory space.
 ///
@@ -22,70 +47,89 @@ pub const MIN_PHYSMEM_SIZE: usize = BOOT_PDE.as_u64() as usize + 0x1000;
 /// Also, the memory `mem` needs to be zeroed for [`PAGE_SIZE`] bytes at the
 /// offsets [`BOOT_PML4`] and [`BOOT_PDPTE`], otherwise the integrity of the
 /// pagetables and thus the integrity of the guest's memory is not ensured
-pub fn initialize_pagetables(mem: &mut [u8]) {
+/// `mem` and `GuestPhysAddr` must be 2MiB page aligned.
+/// length is the size of the identity mapped region in bytes.
+pub fn initialize_pagetables(
+	mem: &mut [u8],
+	guest_address: GuestPhysAddr,
+	length: u64,
+	// TODO: deprecate the legacy_mapping option once hermit pre 0.10.0 isn't a thing anymore.
+	legacy_mapping: bool,
+) {
 	assert!(mem.len() >= MIN_PHYSMEM_SIZE);
 	let mem_addr = std::ptr::addr_of_mut!(mem[0]);
 
-	let (gdt_entry, pml4, pdpte, pde);
+	let (gdt_entry, pml4);
 	// Safety:
 	// We only operate in `mem`, which is plain bytes and we have ownership of
 	// these and it is asserted to be large enough.
 	unsafe {
 		gdt_entry = mem_addr
-			.add(BOOT_GDT.as_u64() as usize)
+			.add(GDT_OFFSET as usize)
 			.cast::<[u64; 3]>()
 			.as_mut()
 			.unwrap();
 
 		pml4 = mem_addr
-			.add(BOOT_PML4.as_u64() as usize)
+			.add(PML4_OFFSET as usize)
 			.cast::<PageTable>()
 			.as_mut()
 			.unwrap();
-		pdpte = mem_addr
-			.add(BOOT_PDPTE.as_u64() as usize)
-			.cast::<PageTable>()
-			.as_mut()
-			.unwrap();
-		pde = mem_addr
-			.add(BOOT_PDE.as_u64() as usize)
-			.cast::<PageTable>()
-			.as_mut()
-			.unwrap();
-
-		/* For simplicity we currently use 2MB pages and only a single
-		PML4/PDPTE/PDE. */
-
-		// per default is the memory zeroed, which we allocate by the system
-		// call mmap, so the following is not necessary:
-		/*libc::memset(pml4 as *mut _ as *mut libc::c_void, 0x00, PAGE_SIZE);
-		libc::memset(pdpte as *mut _ as *mut libc::c_void, 0x00, PAGE_SIZE);
-		libc::memset(pde as *mut _ as *mut libc::c_void, 0x00, PAGE_SIZE);*/
 	}
+
 	// initialize GDT
 	gdt_entry[BOOT_GDT_NULL] = 0;
 	gdt_entry[BOOT_GDT_CODE] = create_gdt_entry(0xA09B, 0, 0xFFFFF);
 	gdt_entry[BOOT_GDT_DATA] = create_gdt_entry(0xC093, 0, 0xFFFFF);
 
-	pml4[0].set_addr(
-		BOOT_PDPTE.into(),
-		PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
-	);
+	// recursive pagetable setup
 	pml4[511].set_addr(
-		BOOT_PML4.into(),
-		PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
-	);
-	pdpte[0].set_addr(
-		BOOT_PDE.into(),
+		(guest_address + PML4_OFFSET).into(),
 		PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
 	);
 
-	for i in 0..512 {
-		let addr = PhysAddr::new(i as u64 * Page::<Size2MiB>::SIZE);
-		pde[i].set_addr(
-			addr,
-			PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::HUGE_PAGE,
+	let mut boot_frame_allocator = BumpAllocator::new(
+		guest_address + PAGETABLES_OFFSET,
+		(PAGETABLES_END - PAGETABLES_OFFSET) / Size4KiB::SIZE,
+	);
+	let page_mapper = UhyvePageTableFrameMapper { mem, guest_address };
+	// Safety: pml4 is zero initialized and page_mapper operates in a correct environment
+	let mut pagetable_mapping = unsafe { MappedPageTable::new(pml4, page_mapper) };
+
+	let mapping_range = if legacy_mapping {
+		debug!("Legacy mapping of the initial memory");
+		let start_page = guest_address;
+		let kernel_start = VirtAddr::new((guest_address + KERNEL_OFFSET).as_u64());
+		let end_page = Page::from_page_table_indices_2mib(
+			kernel_start.p4_index(),
+			kernel_start.p3_index(),
+			PageTableIndex::new(511),
 		);
+		let end = u64::max(
+			end_page.start_address().as_u64(),
+			guest_address.as_u64() + length,
+		);
+		start_page.as_u64()..=end
+	} else {
+		guest_address.as_u64()..=guest_address.as_u64() + length
+	};
+
+	// Map the kernel
+	debug!(
+		"identity mapping from {guest_address:?} to {:?}",
+		guest_address + length
+	);
+	for addr in mapping_range.step_by(Size2MiB::SIZE as usize) {
+		let ga = GuestPhysAddr::new(addr);
+		let _ = unsafe {
+			pagetable_mapping
+				.identity_map(
+					PhysFrame::<Size2MiB>::from_start_address_unchecked(ga.into()),
+					PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::HUGE_PAGE,
+					&mut boot_frame_allocator,
+				)
+				.unwrap()
+		};
 	}
 }
 
@@ -112,10 +156,12 @@ fn pretty_print_pagetable(pt: &PageTable) {
 
 #[cfg(test)]
 mod tests {
+	use uhyve_interface::GuestVirtAddr;
+
 	use super::*;
 	use crate::{
-		consts::{BOOT_PDE, BOOT_PDPTE, BOOT_PML4},
-		mem::HugePageAlignedMem,
+		consts::{GDT_OFFSET, PAGETABLES_END, PAGETABLES_OFFSET, PML4_OFFSET},
+		mem::MmapMemory,
 	};
 
 	#[test]
@@ -125,51 +171,89 @@ mod tests {
 			.is_test(true)
 			.try_init();
 
-		let aligned_mem = HugePageAlignedMem::<MIN_PHYSMEM_SIZE>::new();
-		initialize_pagetables((aligned_mem.mem).try_into().unwrap());
+		let gaddrs = [
+			GuestPhysAddr::new(0x0),
+			GuestPhysAddr::new(0x11120000),
+			GuestPhysAddr::new(0x111ff000),
+			GuestPhysAddr::new(0xe1120000),
+		];
+		for &guest_address in gaddrs.iter() {
+			println!("\n\n---------------------------------------");
+			println!("testing guest address {guest_address:?}");
+			let mem = MmapMemory::new(0, MIN_PHYSMEM_SIZE * 2, guest_address, true, true);
+			initialize_pagetables(
+				unsafe {
+					mem.slice_at_mut(guest_address, MIN_PHYSMEM_SIZE * 2)
+						.unwrap()
+				},
+				guest_address,
+				0x20_0000 * 4,
+				false,
+			);
 
-		// Test pagetable setup
-		let addr_pdpte = u64::from_le_bytes(
-			aligned_mem.mem[(BOOT_PML4.as_u64() as usize)..(BOOT_PML4.as_u64() as usize + 8)]
-				.try_into()
-				.unwrap(),
-		);
-		assert_eq!(
-			addr_pdpte,
-			BOOT_PDPTE.as_u64() | (PageTableFlags::PRESENT | PageTableFlags::WRITABLE).bits()
-		);
-		let addr_pde = u64::from_le_bytes(
-			aligned_mem.mem[(BOOT_PDPTE.as_u64() as usize)..(BOOT_PDPTE.as_u64() as usize + 8)]
-				.try_into()
-				.unwrap(),
-		);
-		assert_eq!(
-			addr_pde,
-			BOOT_PDE.as_u64() | (PageTableFlags::PRESENT | PageTableFlags::WRITABLE).bits()
-		);
+			/// Checks if `address` is in the pagetables.
+			fn check_and_print(
+				address: GuestVirtAddr,
+				phys_addr_offset: GuestPhysAddr,
+				mem: &MmapMemory,
+			) {
+				let idx4 = address.p4_index();
+				let idx3 = address.p3_index();
+				let idx2 = address.p2_index();
+				debug!(
+					"address: {address:#x}: {}-{}-{}",
+					u16::from(idx4),
+					u16::from(idx3),
+					u16::from(idx2)
+				);
+				let pml4 = unsafe { mem.get_ref(phys_addr_offset + PML4_OFFSET).unwrap() };
+				pretty_print_pagetable(pml4);
 
-		for i in (0..4096).step_by(8) {
-			let addr = BOOT_PDE.as_u64() as usize + i;
-			let entry = u64::from_le_bytes(aligned_mem.mem[addr..(addr + 8)].try_into().unwrap());
-			assert!(
-				PageTableFlags::from_bits_truncate(entry)
-					.difference(
-						PageTableFlags::PRESENT
-							| PageTableFlags::WRITABLE
-							| PageTableFlags::HUGE_PAGE
-					)
-					.is_empty(),
-				"Pagetable bits at {addr:#x} are incorrect"
-			)
-		}
+				// Check PDPTE address
+				let addr_pdpte = &pml4[idx4];
+				debug!("addr_ptpde: {addr_pdpte:?}");
+				assert!(
+					addr_pdpte.addr().as_u64() - phys_addr_offset.as_u64() >= PAGETABLES_OFFSET
+				);
+				assert!(addr_pdpte.addr().as_u64() - phys_addr_offset.as_u64() <= PAGETABLES_END);
+				assert!(addr_pdpte
+					.flags()
+					.contains(PageTableFlags::PRESENT | PageTableFlags::WRITABLE));
 
-		// Test GDT
-		let gdt_results = [0x0, 0xAF9B000000FFFF, 0xCF93000000FFFF];
-		for (i, res) in gdt_results.iter().enumerate() {
-			let gdt_addr = BOOT_GDT.as_u64() as usize + i * 8;
-			let gdt_entry =
-				u64::from_le_bytes(aligned_mem.mem[gdt_addr..gdt_addr + 8].try_into().unwrap());
-			assert_eq!(*res, gdt_entry);
+				let pdpte = unsafe { mem.get_ref(addr_pdpte.addr().into()).unwrap() };
+				pretty_print_pagetable(pdpte);
+				let addr_pde = &pdpte[idx3];
+				assert!(addr_pde.addr().as_u64() - phys_addr_offset.as_u64() >= PAGETABLES_OFFSET);
+				assert!(addr_pde.addr().as_u64() - phys_addr_offset.as_u64() <= PAGETABLES_END);
+				assert!(addr_pde
+					.flags()
+					.contains(PageTableFlags::PRESENT | PageTableFlags::WRITABLE));
+
+				let pde = unsafe { mem.get_ref(addr_pde.addr().into()).unwrap() };
+				pretty_print_pagetable(pde);
+				assert_eq!(pde[idx2].addr().as_u64(), address.as_u64());
+			}
+
+			check_and_print(
+				GuestVirtAddr::new(guest_address.as_u64()),
+				guest_address,
+				&mem,
+			);
+			check_and_print(
+				GuestVirtAddr::new(guest_address.as_u64() + 3 * 0x20_0000),
+				guest_address,
+				&mem,
+			);
+
+			// Test GDT
+			let gdt_results = [0x0, 0xAF9B000000FFFF, 0xCF93000000FFFF];
+			for (i, res) in gdt_results.iter().enumerate() {
+				let gdt_addr = guest_address + GDT_OFFSET as usize + i * 8;
+				let gdt_entry = u64::from_le_bytes(unsafe {
+					mem.slice_at(gdt_addr, 8).unwrap().try_into().unwrap()
+				});
+				assert_eq!(*res, gdt_entry);
+			}
 		}
 	}
 }

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -103,6 +103,10 @@ struct MemoryArgs {
 	#[clap(short = 'm', long, default_value_t, env = "HERMIT_MEMORY_SIZE")]
 	memory_size: GuestMemorySize,
 
+	/// Disable ASLR
+	#[clap(long)]
+	no_aslr: bool,
+
 	/// Transparent Hugepages
 	///
 	/// Advise the kernel to enable Transparent Hugepages [THP] on the virtual RAM.
@@ -262,6 +266,7 @@ impl From<Args> for Params {
 			memory_args:
 				MemoryArgs {
 					memory_size,
+					no_aslr,
 					#[cfg(target_os = "linux")]
 					thp,
 					#[cfg(target_os = "linux")]
@@ -290,6 +295,7 @@ impl From<Args> for Params {
 			thp,
 			#[cfg(target_os = "linux")]
 			ksm,
+			aslr: !no_aslr,
 			cpu_count,
 			#[cfg(target_os = "linux")]
 			pit,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,20 +1,27 @@
-use uhyve_interface::GuestPhysAddr;
-
 pub const PAGE_SIZE: usize = 0x1000;
 pub const GDT_KERNEL_CODE: u16 = 1;
 pub const GDT_KERNEL_DATA: u16 = 2;
 pub const APIC_DEFAULT_BASE: u64 = 0xfee00000;
-pub const BOOT_GDT: GuestPhysAddr = GuestPhysAddr::new(0x1000);
+
 pub const BOOT_GDT_NULL: usize = 0;
 pub const BOOT_GDT_CODE: usize = 1;
 pub const BOOT_GDT_DATA: usize = 2;
 pub const BOOT_GDT_MAX: usize = 3;
-pub const BOOT_PML4: GuestPhysAddr = GuestPhysAddr::new(0x10000);
-pub const BOOT_PGT: GuestPhysAddr = BOOT_PML4;
-pub const BOOT_PDPTE: GuestPhysAddr = GuestPhysAddr::new(0x11000);
-pub const BOOT_PDE: GuestPhysAddr = GuestPhysAddr::new(0x12000);
-pub const FDT_ADDR: GuestPhysAddr = GuestPhysAddr::new(0x5000);
-pub const BOOT_INFO_ADDR: GuestPhysAddr = GuestPhysAddr::new(0x9000);
+
+// guest_address + OFFSET
+pub const GDT_OFFSET: u64 = 0x1000;
+pub const FDT_OFFSET: u64 = 0x5000;
+pub const BOOT_INFO_OFFSET: u64 = 0x9000;
+pub const PML4_OFFSET: u64 = 0x10000;
+pub const PGT_OFFSET: u64 = 0x10000;
+pub const PAGETABLES_OFFSET: u64 = 0x11000;
+pub const PAGETABLES_END: u64 = 0x30000;
+pub const KERNEL_OFFSET: u64 = 0x40000;
+
+// The offset of the kernel in the memory.
+// Must be larger than BOOT_INFO_OFFSET + KERNEL_STACK_SIZE
+pub const MIN_PHYSMEM_SIZE: usize = 0x43000;
+
 pub const EFER_SCE: u64 = 1; /* System Call Extensions */
 pub const EFER_LME: u64 = 1 << 8; /* Long mode enable */
 pub const EFER_LMA: u64 = 1 << 10; /* Long mode active (read-only) */

--- a/src/linux/gdb/breakpoints.rs
+++ b/src/linux/gdb/breakpoints.rs
@@ -4,10 +4,7 @@ use gdbstub::target::{self, ext::breakpoints::WatchKind, TargetResult};
 use uhyve_interface::GuestVirtAddr;
 
 use super::GdbUhyve;
-use crate::{
-	arch::x86_64::{registers, virt_to_phys},
-	consts::BOOT_PML4,
-};
+use crate::arch::x86_64::{registers, virt_to_phys};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SwBreakpoint {
 	addr: u64,
@@ -58,7 +55,7 @@ impl target::ext::breakpoints::SwBreakpoint for GdbUhyve {
 					virt_to_phys(
 						GuestVirtAddr::new(addr),
 						&self.vm.peripherals.mem,
-						BOOT_PML4,
+						self.vm.vcpus[0].get_root_pagetable(),
 					)
 					.map_err(|_err| ())?,
 					kind,
@@ -83,7 +80,7 @@ impl target::ext::breakpoints::SwBreakpoint for GdbUhyve {
 					virt_to_phys(
 						GuestVirtAddr::new(addr),
 						&self.vm.peripherals.mem,
-						BOOT_PML4,
+						self.vm.vcpus[0].get_root_pagetable(),
 					)
 					.map_err(|_err| ())?,
 					kind,

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,8 +1,64 @@
 //! General paging related code
+use align_address::Align;
 use thiserror::Error;
+use uhyve_interface::GuestPhysAddr;
 
 #[derive(Error, Debug)]
 pub enum PagetableError {
 	#[error("The accessed virtual address is not mapped")]
 	InvalidAddress,
+}
+
+/// A simple bump allocator for initial boot paging frame allocations.
+///
+/// Only intended for the initial memory creation.
+/// This can not cause UB in the host, but when the allocator is invoked with incorrect memory
+/// bounds, the guest memory will (of course) likely be invalid.
+pub(crate) struct BumpAllocator<const FRAMESIZE: u64> {
+	start: GuestPhysAddr,
+	length: u64,
+	cnt: u64,
+}
+impl<const FRAMESIZE: u64> BumpAllocator<FRAMESIZE> {
+	/// Create a new allocator at `start` with `length` *frames* as capacity
+	///
+	/// - `start` must be 4KiB aligned.
+	/// - If `lenght` exceedes the intended memory region, this allocator will produce invalid
+	///   allocations
+	pub(crate) fn new(start: GuestPhysAddr, length: u64) -> Self {
+		assert!(start.as_u64().is_aligned_to(FRAMESIZE));
+		Self {
+			start,
+			length,
+			cnt: 0,
+		}
+	}
+
+	/// Allocate the next frame with this allocator.
+	pub(crate) fn allocate(&mut self) -> Option<GuestPhysAddr> {
+		if self.cnt < self.length {
+			let f = self.start + self.cnt * FRAMESIZE;
+			self.cnt += 1;
+			Some(f)
+		} else {
+			None
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use uhyve_interface::GuestPhysAddr;
+
+	use super::*;
+
+	#[test]
+	fn test_bump_frame_allocator() {
+		let mut ba = BumpAllocator::<0x1000>::new(GuestPhysAddr::new(0x40_0000), 4);
+		assert_eq!(ba.allocate(), Some(GuestPhysAddr::new(0x40_0000)));
+		assert_eq!(ba.allocate(), Some(GuestPhysAddr::new(0x40_1000)));
+		assert_eq!(ba.allocate(), Some(GuestPhysAddr::new(0x40_2000)));
+		assert_eq!(ba.allocate(), Some(GuestPhysAddr::new(0x40_3000)));
+		assert_eq!(ba.allocate(), None);
+	}
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -50,6 +50,9 @@ pub struct Params {
 
 	/// Environment variables of the kernel
 	pub env: EnvVars,
+
+	/// Load the kernel to a random address
+	pub aslr: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -71,6 +74,7 @@ impl Default for Params {
 			output: Default::default(),
 			stats: false,
 			env: EnvVars::default(),
+			aslr: true,
 		}
 	}
 }

--- a/tests/gdb.rs
+++ b/tests/gdb.rs
@@ -46,7 +46,6 @@ fn gdb() -> io::Result<()> {
 	write!(
 		&mut command_file,
 		"target remote :{port}
-symbol-file {bin_path} -o 0x400000
 break gdb::main
 continue
 
@@ -88,7 +87,6 @@ pipe print _x|cat >> {output_path}
 continue
 ",
 		port = port,
-		bin_path = bin_path.display(),
 		output_path = output_path.display()
 	)?;
 


### PR DESCRIPTION
- Move x86_64-related paging code to src/arch/x86_64/paging
- Tests: x86_64-related paging tests should use a guest_address that is
  not 0
- Tests: Move them in separate files, use appropriate 'use' directives
- Tests: Use init_guest_mem wrapper in test_virt_to_phys
- Fix kernel memory loading
- Add guest_address getter in UhyveVm
- Change names of constants to clarify their purpose
- Remove pagetable_l0 from virt_to_phys function
- Various `cargo fmt`-related changes
- aarch64: Blindly replace constant names and similar RAM_START change

We currently rely on guest_address in MmapMemory to calculate the
offsets during the initialization of the VM and when converting
virtual addresses to physical addresses. The latter case is intended
to be temporary - we should read the value from the CR3 register at
a later point.

Although this current revision does work with relocatable binaries, it
is not making use of this functionality _just_ yet.

Fixes #719.
Fixes #713.