### PR TITLE
feat(vm): change UhyveVm struct parameters

### DIFF
--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -402,12 +402,14 @@ impl VirtualCPU for KvmCpu {
 							hypercall::address_to_hypercall(&self.parent_vm.mem, port, data_addr)
 						} {
 							match hypercall {
-								Hypercall::Cmdsize(syssize) => syssize
-									.update(self.parent_vm.kernel_path(), self.parent_vm.args()),
+								Hypercall::Cmdsize(syssize) => syssize.update(
+									self.parent_vm.kernel_path(),
+									&self.parent_vm.params.kernel_args,
+								),
 								Hypercall::Cmdval(syscmdval) => {
 									hypercall::copy_argv(
 										self.parent_vm.kernel_path().as_os_str(),
-										self.parent_vm.args(),
+										&self.parent_vm.params.kernel_args,
 										syscmdval,
 										&self.parent_vm.mem,
 									);

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -174,12 +174,14 @@ impl VirtualCPU for XhyveCpu {
 								Hypercall::Exit(sysexit) => {
 									return Ok(VcpuStopReason::Exit(sysexit.arg));
 								}
-								Hypercall::Cmdsize(syssize) => syssize
-									.update(self.parent_vm.kernel_path(), self.parent_vm.args()),
+								Hypercall::Cmdsize(syssize) => syssize.update(
+									self.parent_vm.kernel_path(),
+									&self.parent_vm.params.kernel_args,
+								),
 								Hypercall::Cmdval(syscmdval) => {
 									copy_argv(
 										self.parent_vm.kernel_path().as_os_str(),
-										self.parent_vm.args(),
+										&self.parent_vm.params.kernel_args,
 										syscmdval,
 										&self.parent_vm.mem,
 									);

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -720,13 +720,14 @@ impl VirtualCPU for XhyveCpu {
 						hypercall::address_to_hypercall(&self.parent_vm.mem, port, data_addr)
 					} {
 						match hypercall {
-							Hypercall::Cmdsize(syssize) => {
-								syssize.update(self.parent_vm.kernel_path(), self.parent_vm.args())
-							}
+							Hypercall::Cmdsize(syssize) => syssize.update(
+								self.parent_vm.kernel_path(),
+								&self.parent_vm.params.kernel_args,
+							),
 							Hypercall::Cmdval(syscmdval) => {
 								copy_argv(
 									self.parent_vm.kernel_path().as_os_str(),
-									self.parent_vm.args(),
+									&self.parent_vm.params.kernel_args,
 									syscmdval,
 									&self.parent_vm.mem,
 								);


### PR DESCRIPTION
As I was moving some functionality away from new(...) so as to progress with my work on ASLR and some future work, I found it necessary to use certain parameters later. A particular example from UhyveVm's current structure would be params.thp and params.ksm, which pose one of the obstacles preventing us from initializing the memory later (e.g. in load_kernel or init_guest_mem, after loading the kernel and being able to establish a guest address), even though separate variables for those don't make much sense.

This change will mostly be useful for future work, but aims to establish a consistent convention now.