### PR TITLE
uhyve-interface: Don't take ownership on fn port()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "uhyve-interface"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aarch64",
  "log",

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhyve-interface"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [
   "Jonathan Klimt <jonathan.klimt@eonerc.rwth-aachen.de>",

--- a/uhyve-interface/src/lib.rs
+++ b/uhyve-interface/src/lib.rs
@@ -72,8 +72,26 @@ pub enum HypercallAddress {
 	/// Port address = `0x880`
 	SerialBufferWrite = 0x880,
 }
+// TODO: Remove this in the next major version
 impl From<Hypercall<'_>> for HypercallAddress {
 	fn from(value: Hypercall) -> Self {
+		match value {
+			Hypercall::Cmdsize(_) => Self::Cmdsize,
+			Hypercall::Cmdval(_) => Self::Cmdval,
+			Hypercall::Exit(_) => Self::Exit,
+			Hypercall::FileClose(_) => Self::FileClose,
+			Hypercall::FileLseek(_) => Self::FileLseek,
+			Hypercall::FileOpen(_) => Self::FileOpen,
+			Hypercall::FileRead(_) => Self::FileRead,
+			Hypercall::FileWrite(_) => Self::FileWrite,
+			Hypercall::FileUnlink(_) => Self::FileUnlink,
+			Hypercall::SerialWriteByte(_) => Self::Uart,
+			Hypercall::SerialWriteBuffer(_) => Self::SerialBufferWrite,
+		}
+	}
+}
+impl From<&Hypercall<'_>> for HypercallAddress {
+	fn from(value: &Hypercall) -> Self {
 		match value {
 			Hypercall::Cmdsize(_) => Self::Cmdsize,
 			Hypercall::Cmdval(_) => Self::Cmdval,
@@ -114,6 +132,7 @@ pub enum Hypercall<'a> {
 	SerialWriteBuffer(&'a SerialWriteBufferParams),
 }
 impl<'a> Hypercall<'a> {
+	// TODO: Remove this in the next major version
 	/// Get a hypercall's port address.
 	pub fn port(self) -> u16 {
 		HypercallAddress::from(self) as u16


### PR DESCRIPTION
It was almost impossible to use this fn before, as it takes the ownership of the whole struct, making access to the data impossible. 
This was a mistake in the first place and should now be resolved.