### PR TITLE
test: update toolchain channel to `nightly-2024-09-01`

### DIFF
--- a/tests/test-kernels/rust-toolchain.toml
+++ b/tests/test-kernels/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-01"
+channel = "nightly-2024-09-01"
 components = [ "rust-src" ]


### PR DESCRIPTION
Result of the investigation behind the failing tests (https://github.com/hermit-os/uhyve/issues/726), however, this doesn't actually fix anything.