### PR TITLE
fix(params): ambiguous reference to positional arguments

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -126,8 +126,8 @@ impl fmt::Display for GuestMemorySize {
 #[derive(Error, Debug)]
 pub enum InvalidGuestMemorySizeError {
 	#[error(
-		"Not enough guest memory. Must be at least {} (is {0})",
-		GuestMemorySize::minimum()
+		"Not enough guest memory. Must be at least {min} (is {0})",
+		min = GuestMemorySize::minimum()
 	)]
 	MemoryTooSmall(Byte),
 	#[error("Invalid amount of guest memory. Must be a multiple of 2 MiB (is {0})")]


### PR DESCRIPTION
Required for https://github.com/hermit-os/uhyve/pull/786.