### PR TITLE
test: add fs-related helper functions

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,6 @@
 use std::{
 	env,
+	fs::remove_file,
 	path::{Path, PathBuf},
 	process::Command,
 };
@@ -56,4 +57,12 @@ pub fn run_simple_vm(kernel_path: PathBuf) -> VmResult {
 		..Default::default()
 	};
 	UhyveVm::new(kernel_path, params).unwrap().run(None)
+}
+
+/// Removes a file if it already exists on the host OS.
+pub fn remove_file_if_exists(path: &PathBuf) {
+	if path.exists() {
+		println!("Removing existing directory {}", path.display());
+		remove_file(path).unwrap_or_else(|_| panic!("Can't remove {}", path.display()));
+	}
 }

--- a/tests/serial.rs
+++ b/tests/serial.rs
@@ -1,12 +1,9 @@
 mod common;
 
-use std::{
-	fs::{read_to_string, remove_file},
-	path::PathBuf,
-};
+use std::{fs::read_to_string, path::PathBuf};
 
 use byte_unit::{Byte, Unit};
-use common::{build_hermit_bin, run_simple_vm};
+use common::{build_hermit_bin, remove_file_if_exists, run_simple_vm};
 use uhyvelib::{
 	params::{Output, Params},
 	vm::UhyveVm,
@@ -30,11 +27,7 @@ fn serial_file_output_test() {
 	env_logger::try_init().ok();
 	let bin_path = build_hermit_bin("serial");
 	let output_path: PathBuf = "testserialout.txt".into();
-	if output_path.exists() {
-		println!("Removing existing file {}", output_path.display());
-		remove_file(&output_path)
-			.unwrap_or_else(|_| panic!("Can't remove {}", output_path.display()));
-	}
+	remove_file_if_exists(&output_path);
 
 	println!("Launching kernel {}", bin_path.display());
 	let params = Params {
@@ -55,5 +48,5 @@ fn serial_file_output_test() {
 	let file_content = read_to_string(&output_path).unwrap();
 	assert!(file_content.contains("Hello from serial!\nABCD\n1234ASDF!@#$\n"));
 
-	remove_file(&output_path).unwrap_or_else(|_| panic!("Can't remove {}", output_path.display()));
+	remove_file_if_exists(&output_path);
 }


### PR DESCRIPTION
This should help us keep up with the increasing complexity of the tests (including for features currently being developed). verify_file_equals is not particularly useful right now, but I intend on using it more intensively for the UhyveFileMap feature much more extensively.