### PR TITLE
nit(hypercall): remove unnecessary .as_bytes() call

### DIFF
--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -259,7 +259,7 @@ pub fn copy_argv(path: &OsStr, argv: &[String], syscmdval: &CmdvalParams, mem: &
 
 	// Copy the application arguments into the vm memory
 	for (counter, argument) in argv.iter().enumerate() {
-		let len = argument.as_bytes().len();
+		let len = argument.len();
 		let arg_dest = unsafe {
 			mem.slice_at_mut(arg_addrs[counter], len + 1)
 				.expect("Systemcall parameters for Cmdval are invalid")


### PR DESCRIPTION
See 'https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes'