### PR TITLE
refactor: split isolation.rs into files

### DIFF
--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -9,7 +9,7 @@ use uhyve_interface::{parameters::*, GuestPhysAddr, Hypercall, HypercallAddress,
 
 use crate::{
 	consts::BOOT_PML4,
-	isolation::UhyveFileMap,
+	isolation::filemap::UhyveFileMap,
 	mem::{MemoryError, MmapMemory},
 	virt_to_phys,
 	vm::{UhyveVm, VirtualizationBackend},

--- a/src/isolation/filemap.rs
+++ b/src/isolation/filemap.rs
@@ -1,29 +1,10 @@
 use std::{
 	collections::HashMap,
 	ffi::{CString, OsString},
-	fs::{canonicalize, Permissions},
-	os::unix::{ffi::OsStrExt, fs::PermissionsExt},
+	fs::canonicalize,
+	os::unix::ffi::OsStrExt,
 	path::{absolute, PathBuf},
 };
-
-use tempfile::{Builder, TempDir};
-use uuid::Uuid;
-
-/// Creates a temporary directory.
-pub fn create_temp_dir() -> TempDir {
-	let dir = Builder::new()
-		.permissions(Permissions::from_mode(0o700))
-		.prefix("uhyve-")
-		.suffix(&Uuid::new_v4().to_string())
-		.tempdir()
-		.ok()
-		.unwrap_or_else(|| panic!("The temporary directory could not be created."));
-
-	let dir_permissions = dir.path().metadata().unwrap().permissions();
-	assert!(!dir_permissions.readonly());
-
-	dir
-}
 
 /// Wrapper around a `HashMap` to map guest paths to arbitrary host paths.
 #[derive(Debug, Clone)]

--- a/src/isolation/mod.rs
+++ b/src/isolation/mod.rs
@@ -1,0 +1,2 @@
+pub mod filemap;
+pub mod tempdir;

--- a/src/isolation/tempdir.rs
+++ b/src/isolation/tempdir.rs
@@ -1,0 +1,19 @@
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+
+use tempfile::{Builder, TempDir};
+use uuid::Uuid;
+/// Creates a temporary directory.
+pub fn create_temp_dir() -> TempDir {
+	let dir = Builder::new()
+		.permissions(Permissions::from_mode(0o700))
+		.prefix("uhyve-")
+		.suffix(&Uuid::new_v4().to_string())
+		.tempdir()
+		.ok()
+		.unwrap_or_else(|| panic!("The temporary directory could not be created."));
+
+	let dir_permissions = dir.path().metadata().unwrap().permissions();
+	assert!(!dir_permissions.readonly());
+
+	dir
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -26,7 +26,7 @@ use crate::{
 	arch::{self, FrequencyDetectionFailed},
 	consts::*,
 	fdt::Fdt,
-	isolation::*,
+	isolation::{filemap::UhyveFileMap, tempdir::create_temp_dir},
 	mem::MmapMemory,
 	os::HypervisorError,
 	params::{self, Params},


### PR DESCRIPTION
This is a form of preparation for the introduction of additional security-related measures, which may be best to implement in separate files.