### PR TITLE
nit(cli): move file_mapping further up in Args

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -48,6 +48,14 @@ struct Args {
 	#[clap(long)]
 	stats: bool,
 
+	/// Paths that the kernel should be able to view, read or write.
+	///
+	/// Desired paths must be explicitly defined after a colon.
+	///
+	/// Example: --file-mapping host_dir:guest_dir --file-mapping file.txt:guest_file.txt
+	#[clap(long)]
+	file_mapping: Vec<String>,
+
 	#[clap(flatten, next_help_heading = "Memory OPTIONS")]
 	memory_args: MemoryArgs,
 
@@ -60,14 +68,6 @@ struct Args {
 	#[clap(short = 's', long, env = "HERMIT_GDB_PORT")]
 	#[cfg(target_os = "linux")]
 	gdb_port: Option<u16>,
-
-	/// Paths that the kernel should be able to view, read or write.
-	///
-	/// Desired paths must be explicitly defined after a colon.
-	///
-	/// Example: --file-mapping host_dir:guest_dir --file-mapping file.txt:guest_file.txt
-	#[clap(long)]
-	file_mapping: Vec<String>,
 
 	/// The kernel to execute
 	#[clap(value_parser)]


### PR DESCRIPTION
It makes sense to group it togehter with output and stats, instead of pushing it all the way down beneath the Memory and Cpu help headings. We presume that the settings under those headings to be more "optional" than --file-mapping, as the defaults do not have to be changed very often.