### PR TITLE
fix(hypercall): use sanitized flags for mapped files

### DIFF
--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -107,13 +107,8 @@ pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFile
 			// As host_path_c_string is a valid CString, this implementation is presumed to be safe.
 			let host_path_c_string = CString::new(host_path.as_bytes()).unwrap();
 
-			sysopen.ret = unsafe {
-				libc::open(
-					host_path_c_string.as_c_str().as_ptr(),
-					sysopen.flags,
-					sysopen.mode,
-				)
-			};
+			sysopen.ret =
+				unsafe { libc::open(host_path_c_string.as_c_str().as_ptr(), flags, sysopen.mode) };
 		} else {
 			debug!("Attempting to open a temp file for {:#?}...", guest_path);
 

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -92,7 +92,7 @@ pub fn unlink(mem: &MmapMemory, sysunlink: &mut UnlinkParams, file_map: &mut Uhy
 		}
 	} else {
 		error!("The kernel requested to open() a path that is not valid UTF-8. Rejecting...");
-		sysunlink.ret = -EIO;
+		sysunlink.ret = -EINVAL;
 	}
 }
 

--- a/uhyve-interface/src/parameters.rs
+++ b/uhyve-interface/src/parameters.rs
@@ -160,5 +160,4 @@ pub const ALLOWED_OPEN_FLAGS: i32 =
 	O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_TRUNC | O_APPEND | O_DIRECT | O_DIRECTORY;
 
 pub const ENOENT: i32 = 2;
-pub const EIO: i32 = 5;
 pub const EINVAL: i32 = 22;


### PR DESCRIPTION
Just spotted this unfortunate error, oops.