### PR TITLE
fix(sysinfo): do not use sysinfo on x86_64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ virtio-bindings = { version = "0.2", features = ["virtio-v4_14_0"] }
 rftrace = { version = "0.1", optional = true }
 rftrace-frontend = { version = "0.1", optional = true }
 shell-words = "1"
-sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 vm-fdt = "0.3"
 tempfile = "3.15.0"
 uuid = { version = "1.11.1", features = ["fast-rng", "v4"]}
@@ -85,6 +84,7 @@ memory_addresses = { version = "0.2.2", default-features = false, features = [
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 bitflags = "2.7"
+sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 memory_addresses = { version = "0.2.2", default-features = false, features = [
   "aarch64",
 ] }


### PR DESCRIPTION
The frequency is not meant to be a frequency that the Hermit kernel can access instead of the real-time frequency value. Hermit uses this values as some sort of a nominal frequency for counting ticks (see constant_tsc) internally. Having to rely on sysinfo is a "worst-case" scenario for architectures that do not have CPUID-like functionalities (or, if they do, we do not handle them properly yet.)

Fixes https://github.com/hermit-os/uhyve/issues/862