### PR TITLE
Use sealed trait pattern to avoid private trait in public interface warning

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 	serial::Destination,
 	stats::{CpuStats, VmStats},
 	vcpu::VirtualCPU,
-	vm::{UhyveVm, VirtualizationBackend, VmResult},
+	vm::{internal::VirtualizationBackendInternal, UhyveVm, VmResult},
 };
 
 static KVM: LazyLock<Kvm> = LazyLock::new(|| Kvm::new().unwrap());

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -15,7 +15,7 @@ use crate::{
 	stats::{CpuStats, VmExit},
 	vcpu::{VcpuStopReason, VirtualCPU},
 	virtio::*,
-	vm::{UhyveVm, VirtualizationBackend},
+	vm::{internal::VirtualizationBackendInternal, UhyveVm, VirtualizationBackend},
 	HypervisorResult,
 };
 
@@ -33,7 +33,7 @@ const KVM_32BIT_GAP_START: usize = KVM_32BIT_MAX_MEM_SIZE - KVM_32BIT_GAP_SIZE;
 pub struct KvmVm {
 	vm_fd: VmFd,
 }
-impl VirtualizationBackend for KvmVm {
+impl VirtualizationBackendInternal for KvmVm {
 	type VCPU = KvmCpu;
 	const NAME: &str = "KvmVm";
 
@@ -143,6 +143,10 @@ impl VirtualizationBackend for KvmVm {
 
 		Ok(Self { vm_fd: vm })
 	}
+}
+
+impl VirtualizationBackend for KvmVm {
+	type BACKEND = Self;
 }
 
 pub struct KvmCpu {

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -20,12 +20,12 @@ use crate::{
 	params::Params,
 	stats::{CpuStats, VmExit},
 	vcpu::{VcpuStopReason, VirtualCPU},
-	vm::{UhyveVm, VirtualizationBackend},
+	vm::{internal::VirtualizationBackendInternal, UhyveVm, VirtualizationBackend},
 	HypervisorResult,
 };
 
 pub struct XhyveVm {}
-impl VirtualizationBackend for XhyveVm {
+impl VirtualizationBackendInternal for XhyveVm {
 	type VCPU = XhyveCpu;
 	const NAME: &str = "XhyveVm";
 
@@ -58,6 +58,10 @@ impl VirtualizationBackend for XhyveVm {
 		map_mem(unsafe { mem.as_slice_mut() }, 0, MemPerm::ExecAndWrite)?;
 		Ok(Self {})
 	}
+}
+
+impl VirtualizationBackend for XhyveVm {
+	type BACKEND = Self;
 }
 
 pub struct XhyveCpu {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -17,7 +17,7 @@ pub use crate::macos::x86_64::vcpu::{XhyveCpu, XhyveVm};
 use crate::{
 	stats::VmStats,
 	vcpu::VirtualCPU,
-	vm::{UhyveVm, VirtualizationBackend, VmResult},
+	vm::{internal::VirtualizationBackendInternal, UhyveVm, VmResult},
 };
 
 pub type DebugExitInfo = ();

--- a/src/macos/x86_64/vcpu.rs
+++ b/src/macos/x86_64/vcpu.rs
@@ -37,7 +37,7 @@ use crate::{
 	params::Params,
 	stats::{CpuStats, VmExit},
 	vcpu::{VcpuStopReason, VirtualCPU},
-	vm::{UhyveVm, VirtualizationBackend},
+	vm::{internal::VirtualizationBackendInternal, UhyveVm, VirtualizationBackend},
 	HypervisorResult,
 };
 
@@ -157,7 +157,7 @@ static CAP_EXIT: LazyLock<u64> = LazyLock::new(|| {
 });
 
 pub struct XhyveVm {}
-impl VirtualizationBackend for XhyveVm {
+impl VirtualizationBackendInternal for XhyveVm {
 	type VCPU = XhyveCpu;
 	const NAME: &str = "XhyveVm";
 
@@ -191,6 +191,10 @@ impl VirtualizationBackend for XhyveVm {
 		map_mem(unsafe { mem.as_slice_mut() }, 0, MemPerm::ExecAndWrite)?;
 		Ok(Self {})
 	}
+}
+
+impl VirtualizationBackend for XhyveVm {
+	type BACKEND = Self;
 }
 
 pub struct XhyveCpu {


### PR DESCRIPTION
I don't particularly like this, as the functions of the sealed trait are still visible, but it is at least better than before.