### PR TITLE
Removed unwanted `pub` from uhyvelib

### DIFF
--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -1,13 +1,14 @@
-pub mod paging;
-pub mod registers;
+mod paging;
+pub(crate) mod registers;
 
+use paging::initialize_pagetables;
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 use x86_64::structures::paging::{
 	page_table::{FrameError, PageTableEntry},
 	PageTable, PageTableIndex,
 };
 
-use crate::{arch::paging::initialize_pagetables, mem::MmapMemory, paging::PagetableError};
+use crate::{mem::MmapMemory, paging::PagetableError};
 
 pub const RAM_START: GuestPhysAddr = GuestPhysAddr::new(0x00);
 
@@ -62,10 +63,7 @@ mod tests {
 	use x86_64::structures::paging::PageTableFlags;
 
 	use super::*;
-	use crate::{
-		arch::paging::MIN_PHYSMEM_SIZE,
-		consts::{BOOT_PDE, BOOT_PDPTE, BOOT_PML4},
-	};
+	use crate::consts::{BOOT_PDE, BOOT_PDPTE, BOOT_PML4};
 
 	#[test]
 	fn test_virt_to_phys() {
@@ -76,7 +74,7 @@ mod tests {
 
 		let mem = MmapMemory::new(
 			0,
-			align_up!(MIN_PHYSMEM_SIZE * 2, 0x20_0000),
+			align_up!(paging::MIN_PHYSMEM_SIZE * 2, 0x20_0000),
 			GuestPhysAddr::zero(),
 			true,
 			true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,21 +17,21 @@ mod fdt;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]
-pub use linux as os;
+use linux as os;
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]
-pub use macos as os;
+use macos as os;
 mod hypercall;
 mod isolation;
 pub mod mem;
-pub mod paging;
+pub(crate) mod paging;
 pub mod params;
 mod serial;
 pub mod stats;
 mod vcpu;
-pub mod virtio;
-pub mod virtqueue;
+mod virtio;
+mod virtqueue;
 pub mod vm;
 
 pub use arch::*;

--- a/src/linux/gdb/mod.rs
+++ b/src/linux/gdb/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 	HypervisorError, HypervisorResult,
 };
 
-pub struct GdbUhyve {
+pub(crate) struct GdbUhyve {
 	pub(crate) vm: UhyveVm<KvmVm>,
 	hw_breakpoints: HwBreakpoints,
 	sw_breakpoints: SwBreakpoints,
@@ -192,7 +192,7 @@ impl target::ext::base::singlethread::SingleThreadSingleStep for GdbUhyve {
 	}
 }
 
-pub enum UhyveGdbEventLoop {}
+pub(crate) enum UhyveGdbEventLoop {}
 
 impl run_blocking::BlockingEventLoop for UhyveGdbEventLoop {
 	type Target = GdbUhyve;

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
-pub mod gdb;
+pub(crate) mod gdb;
 
-pub type DebugExitInfo = kvm_bindings::kvm_debug_exit_arch;
+pub(crate) type DebugExitInfo = kvm_bindings::kvm_debug_exit_arch;
 
 use std::{
 	io,

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -340,12 +340,8 @@ impl KvmCpu {
 		println!("{name}       {seg:?}");
 	}
 
-	pub fn get_vcpu(&self) -> &VcpuFd {
+	pub(crate) fn get_vcpu(&self) -> &VcpuFd {
 		&self.vcpu
-	}
-
-	pub fn get_vcpu_mut(&mut self) -> &mut VcpuFd {
-		&mut self.vcpu
 	}
 
 	fn init(&mut self, cpu_id: u32) -> HypervisorResult<()> {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -42,7 +42,7 @@ impl KickSignal {
 	}
 }
 
-pub type DebugExitInfo = ();
+pub(crate) type DebugExitInfo = ();
 
 impl UhyveVm<XhyveVm> {
 	/// Runs the VM.

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(target_os = "macos", allow(dead_code))] // no virtio implementation for macos
 use std::{fmt, mem::size_of, ptr::copy_nonoverlapping, sync::Mutex, vec::Vec};
 
 use log::info;
@@ -81,7 +82,6 @@ macro_rules! write_u16 {
 	};
 }
 
-#[macro_export]
 macro_rules! read_u32 {
 	($registers:expr, $address:expr) => {
 		($registers[$address] as u32)

--- a/src/virtqueue.rs
+++ b/src/virtqueue.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(target_os = "macos", allow(dead_code))] // no virtio implementation for macos
 use std::{marker::PhantomData, mem, mem::size_of};
 
 use crate::consts::PAGE_SIZE;
@@ -68,6 +69,7 @@ pub struct Virtqueue {
 	pub available_ring: VringAvailable,
 	pub used_ring: VringUsed,
 	pub last_seen_available: u16,
+	#[allow(dead_code)]
 	pub last_seen_used: u16,
 	pub queue_size: u16,
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -46,7 +46,7 @@ pub enum LoadKernelError {
 	InsufficientMemory,
 }
 
-pub type LoadKernelResult<T> = Result<T, LoadKernelError>;
+type LoadKernelResult<T> = Result<T, LoadKernelError>;
 
 #[cfg(target_os = "linux")]
 pub type DefaultBackend = crate::linux::x86_64::kvm_cpu::KvmVm;


### PR DESCRIPTION
There are many components marked `pub` in uhyvelib that are actually not meant to be exposed. This is not only bad design, but also prevents `dead_code` lints. This is an attempt to fix this partly