### PR TITLE
Minor fixes

### DIFF
--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -550,6 +550,19 @@ impl VirtualCPU for KvmCpu {
 							}
 						}
 					}
+					VcpuExit::MmioRead(addr, _targ) => {
+						match addr {
+							0x9_F000..0xA_0000 | 0xF_0000..0x10_0000 => {} // Search for MP floating table
+							_ => {
+								self.print_registers();
+								panic!("mmio read to {addr:#x}");
+							}
+						}
+					}
+					VcpuExit::MmioWrite(addr, _targ) => {
+						self.print_registers();
+						panic!("undefined mmio write to {addr:#x}");
+					}
 					VcpuExit::Debug(debug) => {
 						if let Some(s) = self.stats.as_mut() {
 							s.increment_val(VmExit::Debug)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -96,7 +96,7 @@ impl MmapMemory {
 	/// the returned slice, the memory must not be altered to prevent undfined
 	/// behaviour.
 	pub unsafe fn slice_at(&self, addr: GuestPhysAddr, len: usize) -> Result<&[u8], MemoryError> {
-		if addr.as_u64() as usize + len >= self.memory_size - self.guest_address.as_u64() as usize {
+		if addr.as_u64() as usize + len >= self.memory_size + self.guest_address.as_u64() as usize {
 			Err(MemoryError::BoundsViolation)
 		} else {
 			Ok(unsafe { std::slice::from_raw_parts(self.host_address(addr)?, len) })
@@ -115,7 +115,7 @@ impl MmapMemory {
 		addr: GuestPhysAddr,
 		len: usize,
 	) -> Result<&mut [u8], MemoryError> {
-		if addr.as_u64() as usize + len >= self.memory_size - self.guest_address.as_u64() as usize {
+		if addr.as_u64() as usize + len > self.memory_size + self.guest_address.as_u64() as usize {
 			Err(MemoryError::BoundsViolation)
 		} else {
 			Ok(unsafe { std::slice::from_raw_parts_mut(self.host_address(addr)? as *mut u8, len) })


### PR DESCRIPTION
Fixed incorrect bounds check and allow MMIO writes to `0x9_F000..0xA_0000 | 0xF_0000..0x10_0000`, which is the location of the MP floating table and might cause exits, once there is no real memory backing for these addresses.