### PR TITLE
Use image runs for Coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,13 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Generate code coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
+        run: |
+          cargo llvm-cov --no-report run data/x86_64/hello_world --stats
+          cargo llvm-cov --no-report run data/x86_64/rusty_demo --stats
+          cargo llvm-cov --no-report run data/x86_64/hello_c --stats
+          cargo llvm-cov --lcov --output-path lcov.info
+
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -7,7 +7,7 @@ use core_affinity::CoreId;
 use either::Either;
 use thiserror::Error;
 use uhyvelib::{
-	params::{CpuCount, GuestMemorySize, Output, Params},
+	params::{CpuCount, EnvVars, GuestMemorySize, Output, Params},
 	vm::UhyveVm,
 };
 
@@ -72,6 +72,11 @@ struct Args {
 	#[clap(short = 's', long, env = "HERMIT_GDB_PORT")]
 	#[cfg(target_os = "linux")]
 	gdb_port: Option<u16>,
+
+	/// Environment variables of the guest as env=value paths. `-e host` passes all variables of the parent process to the kernel.
+	/// Example: --env_vars ASDF=jlk -e TERM=uhyveterm2000
+	#[clap(short = 'e', long)]
+	env_vars: Vec<String>,
 
 	#[clap(flatten, next_help_heading = "Memory OPTIONS")]
 	memory_args: MemoryArgs,
@@ -272,6 +277,7 @@ impl From<Args> for Params {
 			kernel_args,
 			output,
 			stats,
+			env_vars,
 		} = args;
 		Self {
 			memory_size,
@@ -296,6 +302,7 @@ impl From<Args> for Params {
 				Output::StdIo
 			},
 			stats,
+			env: EnvVars::from(env_vars.as_slice()),
 		}
 	}
 }

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -452,7 +452,11 @@ impl VirtualCPU for KvmCpu {
 										syscmdval,
 										&self.peripherals.mem,
 									);
-									hypercall::copy_env(syscmdval, &self.peripherals.mem);
+									hypercall::copy_env(
+										&self.kernel_info.params.env,
+										syscmdval,
+										&self.peripherals.mem,
+									);
 								}
 								Hypercall::Exit(sysexit) => {
 									return Ok(VcpuStopReason::Exit(sysexit.arg));

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -256,7 +256,11 @@ impl VirtualCPU for XhyveCpu {
 										syscmdval,
 										&self.peripherals.mem,
 									);
-									copy_env(syscmdval, &self.peripherals.mem);
+									copy_env(
+										&self.kernel_info.params.env,
+										syscmdval,
+										&self.peripherals.mem,
+									);
 								}
 								Hypercall::FileClose(sysclose) => hypercall::close(sysclose),
 								Hypercall::FileLseek(syslseek) => hypercall::lseek(syslseek),

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,0 +1,76 @@
+mod common;
+
+use std::collections::HashMap;
+
+use byte_unit::{Byte, Unit};
+use common::{build_hermit_bin, check_result};
+use uhyvelib::{
+	params::{EnvVars, Output, Params},
+	vm::UhyveVm,
+};
+
+#[test]
+fn selective_env_test() {
+	env_logger::try_init().ok();
+	let bin_path = build_hermit_bin("env");
+
+	let env_vars = [
+		("ASDF".to_string(), "ASDF".to_string()),
+		("a0978gbsdf".to_string(), ";3254jgnsadfg".to_string()),
+		("EMOJI".to_string(), "🙂".to_string()),
+	];
+
+	println!("Launching kernel {}", bin_path.display());
+	let params = Params {
+		cpu_count: 2.try_into().unwrap(),
+		memory_size: Byte::from_u64_with_unit(64, Unit::MiB)
+			.unwrap()
+			.try_into()
+			.unwrap(),
+		output: Output::Buffer,
+		env: EnvVars::Set(HashMap::from(env_vars.clone())),
+		..Default::default()
+	};
+	let vm = UhyveVm::new(bin_path, params).unwrap();
+	let res = vm.run(None);
+	check_result(&res);
+	println!("{:?}", res.output.as_ref().unwrap());
+	for (key, value) in env_vars.iter() {
+		assert!(res
+			.output
+			.as_ref()
+			.unwrap()
+			.contains(&format!("ENVIRONMENT: {key}: {value}")));
+	}
+}
+
+#[test]
+fn host_env_test() {
+	env_logger::try_init().ok();
+	let bin_path = build_hermit_bin("env");
+
+	println!("Launching kernel {}", bin_path.display());
+	let params = Params {
+		cpu_count: 2.try_into().unwrap(),
+		memory_size: Byte::from_u64_with_unit(64, Unit::MiB)
+			.unwrap()
+			.try_into()
+			.unwrap(),
+		output: Output::Buffer,
+		env: EnvVars::Host,
+		..Default::default()
+	};
+	let vm = UhyveVm::new(bin_path, params).unwrap();
+	let res = vm.run(None);
+	check_result(&res);
+	println!("{:?}", res.output.as_ref().unwrap());
+
+	let common_env_vars = ["PWD", "CARGO_MANIFEST_DIR"];
+	for env in common_env_vars.iter() {
+		assert!(res
+			.output
+			.as_ref()
+			.unwrap()
+			.contains(&format!("ENVIRONMENT: {env}:")));
+	}
+}

--- a/tests/test-kernels/src/bin/env.rs
+++ b/tests/test-kernels/src/bin/env.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	println!("Environment Test");
+	for (key, value) in env::vars() {
+		println!("ENVIRONMENT: {key}: {value}");
+	}
+}


### PR DESCRIPTION
I think it might make sense to include them in the coverage generation.

Alternative:
- Create an _integration test_ that executes these images