### PR TITLE
ci: prepare running KVM jobs on GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           sudo apt-get install gdb
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mkroening/rust-toolchain-toml@main
+        with:
+          toolchain-file: 'tests/test-kernels/rust-toolchain.toml'
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -134,6 +137,9 @@ jobs:
           sudo apt-get install gdb
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mkroening/rust-toolchain-toml@main
+        with:
+          toolchain-file: 'tests/test-kernels/rust-toolchain.toml'
       - name: Install cargo-llvm-cov
         run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1545,7 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "hermit-entry",
+ "home",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,4 +96,5 @@ memory_addresses = { version = "0.2.2", default-features = false, features = [
 [dev-dependencies]
 assert_fs = "1"
 criterion = "0.5"
+home = "0.5"
 regex = { version = "1.11.1", default-features = false, features = ["unicode-perl"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,0 @@
-[toolchain]
-components = [
-    "rustfmt",
-    "clippy",
-    "llvm-tools-preview",
-]

--- a/tests/gdb.rs
+++ b/tests/gdb.rs
@@ -6,12 +6,11 @@ mod common;
 use std::{
 	fs::File,
 	io::{self, Write},
-	process::Command,
 	thread,
 };
 
 use assert_fs::{assert::PathAssert, fixture::PathChild, TempDir};
-use common::build_hermit_bin;
+use common::{build_hermit_bin, rust_gdb};
 use uhyvelib::{
 	params::{Output, Params},
 	vm::UhyveVm,
@@ -90,7 +89,7 @@ continue
 		output_path = output_path.display()
 	)?;
 
-	let status = Command::new("rust-gdb")
+	let status = rust_gdb()
 		.arg("-batch-silent")
 		.arg(format!("-command={}", command_path.display()))
 		.arg(&bin_path)


### PR DESCRIPTION
This prepares https://github.com/hermit-os/uhyve/pull/748, which we don't want to merge right now.