### PR TITLE
fix: provide type annotations in comparisons

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -236,7 +236,7 @@ impl CpuArgs {
 	fn get_affinity(self, app: &mut Command) -> Option<Vec<CoreId>> {
 		self.affinity.map(|affinity| {
 			let affinity_num_vals = affinity.0.len();
-			let cpus_num_vals = self.cpu_count.get().try_into().unwrap();
+			let cpus_num_vals = usize::try_from(self.cpu_count.get()).unwrap();
 			if affinity_num_vals != cpus_num_vals {
 				let affinity_arg = app
 					.get_arguments()

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -277,7 +277,7 @@ pub fn copy_env(env: &EnvVars, syscmdval: &CmdvalParams, mem: &MmapMemory) {
 			.map(|(a, b)| (a.to_owned(), b.to_owned()))
 			.collect(),
 	};
-	if env.len() >= MAX_ARGC_ENVC.try_into().unwrap() {
+	if env.len() >= usize::try_from(MAX_ARGC_ENVC).unwrap() {
 		warn!(
 			"Environment is larger than the maximum that can be copied to the VM. Remaining environment is ignored"
 		);


### PR DESCRIPTION
This is required for upgrading time to 0.3.40, which pulls deranged 0.4.0, which also implements TryFrom for most of these comparisons.

See https://github.com/hermit-os/uhyve/pull/932.