### PR TITLE
Enhanced & fixed CPU initialization

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 		x86_64::kvm_cpu::KvmVm,
 	},
 	serial::Destination,
+	vcpu::VirtualCPU,
 	vm::{UhyveVm, VmResult},
 };
 
@@ -78,7 +79,7 @@ impl UhyveVm<KvmVm> {
 		}
 	}
 
-	fn run_gdb(self, cpu_affinity: Option<Vec<CoreId>>) -> VmResult {
+	fn run_gdb(mut self, cpu_affinity: Option<Vec<CoreId>>) -> VmResult {
 		let cpu_id = 0;
 
 		let local_cpu_affinity = cpu_affinity
@@ -92,6 +93,10 @@ impl UhyveVm<KvmVm> {
 			}
 			None => debug!("No affinity specified, not binding thread"),
 		}
+
+		self.vcpus[0]
+			.thread_local_init()
+			.expect("Unable to initialize vCPU");
 
 		let connection =
 			wait_for_gdb_connection(self.kernel_info.params.gdb_port.unwrap()).unwrap();

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -104,7 +104,7 @@ impl XhyveCpu {
 }
 
 impl VirtualCPU for XhyveCpu {
-	fn init(&mut self) -> HypervisorResult<()> {
+	fn thread_local_init(&mut self) -> HypervisorResult<()> {
 		debug!("Initialize VirtualCPU");
 
 		let (entry_point, stack_address, guest_address, cpu_id) = (

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -32,6 +32,6 @@ pub trait VirtualCPU: Sized + Send {
 	/// Queries the CPUs base frequency in kHz
 	fn get_cpu_frequency(&self) -> Option<NonZeroU32>;
 
-	/// Initialize virtual CPU
-	fn init(&mut self) -> HypervisorResult<()>;
+	/// Perform thread-local initializations for this vcpu
+	fn thread_local_init(&mut self) -> HypervisorResult<()>;
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -303,14 +303,6 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 		})
 	}
 
-	/// Initialized processor `id` for the guest
-	pub fn vcpu_init(&mut self, id: usize) {
-		// initialize virtual processor
-		if self.vcpus[id].init().is_err() {
-			panic!("Unable to initialize vCPU");
-		}
-	}
-
 	pub fn run_no_gdb(self, cpu_affinity: Option<Vec<CoreId>>) -> VmResult {
 		KickSignal::register_handler().unwrap();
 
@@ -338,10 +330,7 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 						None => debug!("No affinity specified, not binding thread"),
 					}
 
-					// initialize virtual processor
-					if cpu.init().is_err() {
-						panic!("Unable to initialize vCPU");
-					}
+					cpu.thread_local_init().expect("Unable to initialize vCPU");
 
 					thread::sleep(std::time::Duration::from_millis(cpu_id as u64 * 50));
 

--- a/tests/gdb.rs
+++ b/tests/gdb.rs
@@ -24,7 +24,7 @@ fn gdb() -> io::Result<()> {
 	let bin_path_clone = bin_path.clone();
 	let vm = thread::spawn(move || {
 		let bin_path = bin_path_clone;
-		let mut vm = UhyveVm::new(
+		let vm = UhyveVm::new(
 			bin_path,
 			Params {
 				gdb_port: Some(port),
@@ -33,7 +33,6 @@ fn gdb() -> io::Result<()> {
 			},
 		)
 		.unwrap();
-		vm.vcpu_init(0);
 		let res = vm.run(None);
 		assert_eq!(0, res.code);
 	});


### PR DESCRIPTION
- renamed `init` -> `thread_local_init`
- call "normal" init for x86_64::kvm_cpu during `new`. This fixes an GDB
  initialization issue, where virtual addresses were queried before the
  CR3 register was set.
- removed `vcpu_init` fn, as initialization is now called either in
  `new` or in `run`.
- call thread_local_initialization in `run_gdb` for linux. Currently
  this has no effect, but probably enhances consistency.
