### PR TITLE
aarch64: fix bug in the initialization of the page tables

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -2,10 +2,11 @@ use std::mem::size_of;
 
 use align_address::Align;
 use bitflags::bitflags;
+use rand::Rng;
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 
 use crate::{
-	consts::{PAGETABLES_END, PAGETABLES_OFFSET, PGT_OFFSET},
+	consts::{KERNEL_OFFSET, PAGETABLES_END, PAGETABLES_OFFSET, PGT_OFFSET},
 	mem::MmapMemory,
 	paging::{BumpAllocator, PagetableError},
 };
@@ -67,6 +68,19 @@ pub const TCR_FLAGS: u64 = TCR_IRGN_WBWA | TCR_ORGN_WBWA | TCR_SHARED;
 
 /// Number of virtual address bits for 4KB page
 pub const VA_BITS: u64 = 48;
+
+/// Generates a random guest address for Uhyve's virtualized memory.
+/// This function gets invoked when a new UhyveVM gets created, provided that the object file is relocatable.
+pub(crate) fn generate_address(object_mem_size: usize) -> GuestPhysAddr {
+	let mut rng = rand::rng();
+	let start_address_upper_bound: u64 =
+		0x0000_0010_0000_0000 - object_mem_size as u64 - KERNEL_OFFSET;
+
+	GuestPhysAddr::new(
+		rng.random_range(RAM_START.as_u64()..start_address_upper_bound)
+			.align_down(0x20_0000),
+	)
+}
 
 #[inline(always)]
 pub const fn tcr_size(x: u64) -> u64 {

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -182,8 +182,6 @@ pub fn init_guest_mem(
 	length: u64,
 	_legacy_mapping: bool,
 ) {
-	warn!("aarch64 pagetable initialization is untested!");
-
 	let mem_addr = std::ptr::addr_of_mut!(mem[0]);
 
 	assert!(mem.len() >= PGT_OFFSET as usize + 512 * size_of::<u64>());

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -1,16 +1,32 @@
 mod paging;
 pub(crate) mod registers;
 
+use align_address::Align;
 use paging::initialize_pagetables;
+use rand::Rng;
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 use x86_64::structures::paging::{
 	PageTable, PageTableIndex,
 	page_table::{FrameError, PageTableEntry},
 };
 
-use crate::{mem::MmapMemory, paging::PagetableError};
+use crate::{consts::KERNEL_OFFSET, mem::MmapMemory, paging::PagetableError};
 
 pub const RAM_START: GuestPhysAddr = GuestPhysAddr::new(0x00);
+
+/// Generates a random guest address for Uhyve's virtualized memory.
+/// This function gets invoked when a new UhyveVM gets created, provided that the object file is relocatable.
+pub(crate) fn generate_address(object_mem_size: usize) -> GuestPhysAddr {
+	let mut rng = rand::rng();
+	// TODO: Also allow mappings beyond the 32 Bit gap
+	let start_address_upper_bound: u64 =
+		0x0000_0000_CFF0_0000 - object_mem_size as u64 - KERNEL_OFFSET;
+
+	GuestPhysAddr::new(
+		rng.random_range(0x0..start_address_upper_bound)
+			.align_down(0x20_0000),
+	)
+}
 
 /// Converts a virtual address in the guest to a physical address in the guest
 pub fn virt_to_phys(

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -65,7 +65,11 @@ impl VirtualizationBackendInternal for KvmVm {
 		Ok(kvcpu)
 	}
 
-	fn new(peripherals: Arc<VmPeripherals>, params: &Params) -> HypervisorResult<Self> {
+	fn new(
+		peripherals: Arc<VmPeripherals>,
+		params: &Params,
+		_guest_addr: GuestPhysAddr,
+	) -> HypervisorResult<Self> {
 		let vm = KVM.create_vm().unwrap();
 
 		let sz = std::cmp::min(peripherals.mem.memory_size, KVM_32BIT_GAP_START);

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -105,7 +105,7 @@ impl XhyveCpu {
 
 impl VirtualCPU for XhyveCpu {
 	fn thread_local_init(&mut self) -> HypervisorResult<()> {
-		debug!("Initialize VirtualCPU");
+		debug!("Initialize VirtualCPU {}", self.id);
 
 		let (entry_point, stack_address, guest_address, cpu_id) = (
 			self.kernel_info.entry_point,

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -23,7 +23,7 @@ impl<const FRAMESIZE: u64> BumpAllocator<FRAMESIZE> {
 	/// Create a new allocator at `start` with `length` *frames* as capacity
 	///
 	/// - `start` must be 4KiB aligned.
-	/// - If `lenght` exceedes the intended memory region, this allocator will produce invalid
+	/// - If `length` exceeds the intended memory region, this allocator will produce invalid
 	///   allocations
 	pub(crate) fn new(start: GuestPhysAddr, length: u64) -> Self {
 		assert!(start.as_u64().is_aligned_to(FRAMESIZE));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -197,6 +197,7 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 		}
 		.into();
 
+		debug!("Guest starts at {guest_address:#x}");
 		debug!("Kernel gets loaded to {kernel_address:#x}");
 
 		#[cfg(target_os = "linux")]


### PR DESCRIPTION
- The Global Interrupt Controller is configured at address 0x8000000. To avoid conflicts, the starting address of the main memory is move to an higher address.
- In addition, a bug in the initialization of the page tables is removed. The calculation of the page table indices was wrong.
- Improve debug messages
- Remove typos in comments
- Like the Hermit loader, the cache is now disabled for I/O devices.
- close #949 
