### PR TITLE
add new hypercall to determine the unix timestamp

### DIFF
--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -321,6 +321,9 @@ impl VirtualCPU for XhyveCpu {
 										sysunlink,
 										&mut self.peripherals.file_mapping.lock().unwrap(),
 									),
+									Hypercall::GetUnixTimestamp(sysgetunixtimestamp) => {
+										hypercall::get_unix_timestamp(sysgetunixtimestamp)
+									}
 									_ => {
 										panic! {"Hypercall {hypercall:?} not implemented on macos-aarch64"}
 									}

--- a/uhyve-interface/src/lib.rs
+++ b/uhyve-interface/src/lib.rs
@@ -64,6 +64,8 @@ pub enum HypercallAddress {
 	FileUnlink = 0x840,
 	/// Port address = `0x880`
 	SerialBufferWrite = 0x880,
+	/// Port address = `0x900`
+	GetUnixTimestamp = 0x900,
 }
 // TODO: Remove this in the next major version
 impl From<Hypercall<'_>> for HypercallAddress {
@@ -80,6 +82,7 @@ impl From<Hypercall<'_>> for HypercallAddress {
 			Hypercall::FileUnlink(_) => Self::FileUnlink,
 			Hypercall::SerialWriteByte(_) => Self::Uart,
 			Hypercall::SerialWriteBuffer(_) => Self::SerialBufferWrite,
+			Hypercall::GetUnixTimestamp(_) => Self::GetUnixTimestamp,
 		}
 	}
 }
@@ -97,6 +100,7 @@ impl From<&Hypercall<'_>> for HypercallAddress {
 			Hypercall::FileUnlink(_) => Self::FileUnlink,
 			Hypercall::SerialWriteByte(_) => Self::Uart,
 			Hypercall::SerialWriteBuffer(_) => Self::SerialBufferWrite,
+			Hypercall::GetUnixTimestamp(_) => Self::GetUnixTimestamp,
 		}
 	}
 }
@@ -123,6 +127,8 @@ pub enum Hypercall<'a> {
 	SerialWriteByte(u8),
 	/// Write a buffer to the terminal.
 	SerialWriteBuffer(&'a SerialWriteBufferParams),
+	/// Returns the unix timestamp
+	GetUnixTimestamp(&'a mut GetUnixTimestampParams),
 }
 impl Hypercall<'_> {
 	// TODO: Remove this in the next major version

--- a/uhyve-interface/src/parameters.rs
+++ b/uhyve-interface/src/parameters.rs
@@ -145,6 +145,13 @@ pub struct SerialWriteBufferParams {
 	pub len: usize,
 }
 
+/// Parameters for a [`GetUnixTimestamp`](crate::Hypercall::GetUnixTimestamp) hypercall.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct GetUnixTimestampParams {
+	pub ret: u64,
+}
+
 // File operations supported by Hermit and Uhyve
 pub const O_RDONLY: i32 = 0o0000;
 pub const O_WRONLY: i32 = 0o0001;


### PR DESCRIPTION
On aarch64, uhyve doesn't support the ARM PrimeCell Real Time Clock(PL031). To detemine the unix timestamp, a new hypercall is introduced, which returns the number of seconds since 1.1.1970