### PR TITLE
encode the timer configuration in the devicetree

### DIFF
--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -115,6 +115,21 @@ impl Fdt {
 	}
 
 	#[cfg(target_arch = "aarch64")]
+	pub fn timer(mut self) -> FdtWriterResult<Self> {
+		let node_name = "timer";
+
+		let timer_node = self.writer.begin_node(node_name)?;
+		self.writer
+			.property_array_u32("interrupts", &[1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4])?;
+		self.writer.property_array_u32("always-on", &[])?;
+		self.writer
+			.property_string("compatible", "arm,armv8-timer")?;
+		self.writer.end_node(timer_node)?;
+
+		Ok(self)
+	}
+
+	#[cfg(target_arch = "aarch64")]
 	pub fn gic(mut self) -> FdtWriterResult<Self> {
 		let node_name = format!("intc@{:x}", GICD_BASE_ADDRESS);
 		let reg = &[

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -119,6 +119,13 @@ impl Fdt {
 		let node_name = "timer";
 
 		let timer_node = self.writer.begin_node(node_name)?;
+
+		// interrupts: Interrupt list for secure, non-secure, virtual and
+		// hypervisor timers
+		// Three values describe one a timer. The first value descibe the typo
+		// of interrupt (1 = PPI), the second value the interrupt number and the
+		// third value specifies a flag (4 = trigger type "level")
+		// The current configuration is equivalent to Qemu's configuration.
 		self.writer
 			.property_array_u32("interrupts", &[1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4])?;
 		self.writer.property_array_u32("always-on", &[])?;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -454,6 +454,7 @@ fn write_fdt_into_mem(mem: &MmapMemory, params: &Params, cpu_freq: Option<NonZer
 	{
 		fdt = fdt.gic().unwrap();
 		fdt = fdt.cpus(params.cpu_count).unwrap();
+		fdt = fdt.timer().unwrap();
 	}
 
 	if let Some(tsc_khz) = cpu_freq {


### PR DESCRIPTION
Without this devicetree node, Hermit will not configure the interrupt handler for the timer interrupt.