### PR TITLE
feat(sandbox): add fd sandbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ instrument = ["rftrace", "rftrace-frontend"]
 align-address = "0.3.0"
 byte-unit = { version = "5", features = ["byte"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-nix = { version = "0.30", features = ["mman", "pthread", "signal"] }
+clean-path = "0.2.1"
 core_affinity = "0.8"
 either = "1.15"
 env_logger = "0.11"
@@ -55,6 +55,7 @@ hermit-entry = { version = "0.10.3", features = ["loader"] }
 libc = "0.2"
 log = "0.4"
 mac_address = "1.1"
+nix = { version = "0.30", features = ["mman", "pthread", "signal"] }
 thiserror = "2.0.9"
 time = "0.3"
 tun-tap = { version = "0.1.3", default-features = false }
@@ -68,7 +69,6 @@ sysinfo = { version = "0.35.1", default-features = false, features = ["system"] 
 vm-fdt = "0.3"
 tempfile = "3.20.0"
 uuid = { version = "1.16.0", features = ["fast-rng", "v4"]}
-clean-path = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = "0.11"

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -1,7 +1,7 @@
 use std::{
 	ffi::{CStr, CString, OsStr},
 	io::{self, Error, ErrorKind},
-	os::unix::ffi::OsStrExt,
+	os::{fd::IntoRawFd, unix::ffi::OsStrExt},
 };
 
 use uhyve_interface::{GuestPhysAddr, Hypercall, HypercallAddress, MAX_ARGC_ENVC, parameters::*};
@@ -78,6 +78,10 @@ pub unsafe fn address_to_hypercall(
 }
 
 /// unlink deletes a name from the filesystem. This is used to handle `unlink` syscalls from the guest.
+///
+/// Note for when using Landlock: Unlinking files results in them being veiled. If a text
+/// file (that existed during initialization) called `log.txt` is unlinked, attempting to
+/// open `log.txt` again will result in an error.
 pub fn unlink(mem: &MmapMemory, sysunlink: &mut UnlinkParams, file_map: &mut UhyveFileMap) {
 	let requested_path = mem.host_address(sysunlink.name).unwrap() as *const i8;
 	if let Ok(guest_path) = unsafe { CStr::from_ptr(requested_path) }.to_str() {
@@ -86,9 +90,6 @@ pub fn unlink(mem: &MmapMemory, sysunlink: &mut UnlinkParams, file_map: &mut Uhy
 			// As host_path_c_string is a valid CString, this implementation is presumed to be safe.
 			let host_path_c_string = CString::new(host_path.as_bytes()).unwrap();
 			sysunlink.ret = unsafe { libc::unlink(host_path_c_string.as_c_str().as_ptr()) };
-			if sysunlink.ret >= 0 {
-				file_map.remove_path(guest_path);
-			}
 		} else {
 			error!("The kernel requested to unlink() an unknown path ({guest_path}): Rejecting...");
 			sysunlink.ret = -ENOENT;
@@ -101,7 +102,6 @@ pub fn unlink(mem: &MmapMemory, sysunlink: &mut UnlinkParams, file_map: &mut Uhy
 
 /// Handles an open syscall by opening a file on the host.
 pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFileMap) {
-	// TODO: Keep track of file descriptors internally, just in case the kernel doesn't close them.
 	let requested_path_ptr = mem.host_address(sysopen.name).unwrap() as *const i8;
 	let mut flags = sysopen.flags & ALLOWED_OPEN_FLAGS;
 	if let Ok(guest_path) = unsafe { CStr::from_ptr(requested_path_ptr) }.to_str() {
@@ -120,6 +120,8 @@ pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFile
 
 			sysopen.ret =
 				unsafe { libc::open(host_path_c_string.as_c_str().as_ptr(), flags, sysopen.mode) };
+
+			file_map.fdmap.insert_fd(sysopen.ret);
 		} else {
 			debug!("{guest_path:#?} not found in file map.");
 			if (flags & O_CREAT) == O_CREAT {
@@ -132,6 +134,7 @@ pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFile
 				let host_path_c_string = file_map.create_temporary_file(guest_path);
 				let new_host_path = host_path_c_string.as_c_str().as_ptr();
 				sysopen.ret = unsafe { libc::open(new_host_path, flags, sysopen.mode) };
+				file_map.fdmap.insert_fd(sysopen.ret.into_raw_fd());
 			} else {
 				debug!("Returning -ENOENT for {guest_path:#?}");
 				sysopen.ret = -ENOENT;
@@ -144,26 +147,44 @@ pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFile
 }
 
 /// Handles an close syscall by closing the file on the host.
-pub fn close(sysclose: &mut CloseParams) {
-	unsafe {
-		sysclose.ret = libc::close(sysclose.fd);
+pub fn close(sysclose: &mut CloseParams, file_map: &mut UhyveFileMap) {
+	if file_map.fdmap.is_fd_present(sysclose.fd.into_raw_fd()) {
+		if sysclose.fd > 2 {
+			unsafe { sysclose.ret = libc::close(sysclose.fd) }
+			file_map.fdmap.remove_fd(sysclose.fd)
+		} else {
+			// Ignore closes of stdin, stdout and stderr that would
+			// otherwise affect Uhyve
+			sysclose.ret = 0
+		}
+	} else {
+		sysclose.ret = -EBADF
 	}
 }
 
-/// Handles an read syscall on the host.
-pub fn read(mem: &MmapMemory, sysread: &mut ReadParams, root_pt: GuestPhysAddr) {
-	unsafe {
-		let bytes_read = libc::read(
-			sysread.fd,
-			mem.host_address(virt_to_phys(sysread.buf, mem, root_pt).unwrap())
-				.unwrap() as *mut libc::c_void,
-			sysread.len,
-		);
-		if bytes_read >= 0 {
-			sysread.ret = bytes_read;
-		} else {
-			sysread.ret = -1;
+/// Handles a read syscall on the host.
+pub fn read(
+	mem: &MmapMemory,
+	sysread: &mut ReadParams,
+	root_pt: GuestPhysAddr,
+	file_map: &mut UhyveFileMap,
+) {
+	if file_map.fdmap.is_fd_present(sysread.fd.into_raw_fd()) {
+		unsafe {
+			let bytes_read = libc::read(
+				sysread.fd,
+				mem.host_address(virt_to_phys(sysread.buf, mem, root_pt).unwrap())
+					.unwrap() as *mut libc::c_void,
+				sysread.len,
+			);
+			if bytes_read >= 0 {
+				sysread.ret = bytes_read;
+			} else {
+				sysread.ret = -1
+			}
 		}
+	} else {
+		sysread.ret = -EBADF as isize;
 	}
 }
 
@@ -172,6 +193,7 @@ pub fn write(
 	peripherals: &VmPeripherals,
 	syswrite: &WriteParams,
 	root_pt: GuestPhysAddr,
+	file_map: &mut UhyveFileMap,
 ) -> io::Result<()> {
 	let mut bytes_written: usize = 0;
 	while bytes_written != syswrite.len {
@@ -182,8 +204,7 @@ pub fn write(
 		)
 		.unwrap();
 
-		if syswrite.fd == 1 {
-			// fd 0 is stdout
+		if syswrite.fd == 1 || syswrite.fd == 2 {
 			let bytes = unsafe {
 				peripherals
 					.mem
@@ -196,6 +217,11 @@ pub fn write(
 					})?
 			};
 			return peripherals.serial.output(bytes);
+		} else if !file_map.fdmap.is_fd_present(syswrite.fd.into_raw_fd()) {
+			// We don't write anything if the file descriptor is not available,
+			// but this is OK for now, as we have no means of returning an error code
+			// and writes are not necessarily guaranteed to write anything.
+			return Ok(());
 		}
 
 		unsafe {
@@ -226,10 +252,16 @@ pub fn write(
 }
 
 /// Handles an write syscall on the host.
-pub fn lseek(syslseek: &mut LseekParams) {
-	unsafe {
-		syslseek.offset =
-			libc::lseek(syslseek.fd, syslseek.offset as i64, syslseek.whence) as isize;
+pub fn lseek(syslseek: &mut LseekParams, file_map: &mut UhyveFileMap) {
+	if file_map.fdmap.is_fd_present(syslseek.fd.into_raw_fd()) {
+		unsafe {
+			syslseek.offset =
+				libc::lseek(syslseek.fd, syslseek.offset as i64, syslseek.whence) as isize;
+		}
+	} else {
+		// TODO: Return -EBADF to the ret field, as soon as it is implemented for LseekParams
+		warn!("lseek attempted to use an unknown file descriptor");
+		syslseek.offset = -1
 	}
 }
 

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -251,7 +251,7 @@ pub fn write(
 	Ok(())
 }
 
-/// Handles an write syscall on the host.
+/// Handles an lseek syscall on the host.
 pub fn lseek(syslseek: &mut LseekParams, file_map: &mut UhyveFileMap) {
 	if file_map.fdmap.is_fd_present(syslseek.fd.into_raw_fd()) {
 		unsafe {

--- a/src/isolation/fd.rs
+++ b/src/isolation/fd.rs
@@ -1,0 +1,72 @@
+use std::{
+	collections::HashSet,
+	os::fd::{FromRawFd, OwnedFd, RawFd},
+};
+
+#[derive(Default, Debug)]
+pub struct UhyveFileDescriptorLayer {
+	fdset: HashSet<RawFd>,
+}
+
+impl UhyveFileDescriptorLayer {
+	/// Returns all present file descriptors.
+	pub(crate) fn get_fds(&self) -> Vec<&i32> {
+		self.fdset.iter().collect::<Vec<_>>()
+	}
+
+	/// Inserts a file descriptor. Invoked by [crate::hypercall::open].
+	///
+	/// Only positive numbers (negative numbers are errors) above
+	/// 2 (0, 1, 2 are standard streams) are accepted.
+	///
+	/// * `fd` - The opened guest path's file descriptor.
+	pub fn insert_fd(&mut self, fd: RawFd) {
+		// Don't insert standard streams (which "conflict" with Uhyve's).
+		if fd > 2 {
+			trace!("Adding fd {fd} to fdset...");
+			self.fdset.insert(fd);
+		} else {
+			warn!("Guest attempted to insert negative/standard stream {fd}, ignoring...")
+		}
+	}
+
+	/// Removes a file descriptor. Invoked by [crate::hypercall::close].
+	///
+	/// Only positive numbers (negative numbers are errors) above
+	/// 2 (0, 1, 2 are standard streams) are accepted.
+	///
+	/// * `fd` - The file descriptor of the file being removed.
+	pub fn remove_fd(&mut self, fd: RawFd) {
+		trace!("remove_fd: {:#?}", &self.fdset);
+		// This is checked by [crate::hypercall::close].
+		if fd > 2 {
+			self.fdset.remove(&fd);
+		} else {
+			warn!("Guest attempted to remove negative/standard stream {fd}, ignoring...")
+		}
+	}
+
+	/// Checks whether an fd exists in this structure, i.e. whether the guest
+	/// should be able to use the fd, as it has been previously opened by the
+	/// guest (and not discarded). Standard streams (file descriptors 0, 1, 2)
+	//// are always considered to be present and return `true`.
+	///
+	/// * `fd` - File descriptor of to-be-operated file.
+	pub fn is_fd_present(&mut self, fd: RawFd) -> bool {
+		trace!("is_fd_present: {:#?}", &self.fdset);
+		if (fd >= 0 && self.fdset.contains(&fd)) || (0..=2).contains(&fd) {
+			return true;
+		}
+		false
+	}
+}
+
+impl Drop for UhyveFileDescriptorLayer {
+	fn drop(&mut self) {
+		for fd in self.get_fds() {
+			// This creates an OwnedFd instance, the RAII variant of RawFd.
+			// We do this to close any files on the host that were not closed by the guest.
+			unsafe { OwnedFd::from_raw_fd(*fd) };
+		}
+	}
+}

--- a/src/isolation/mod.rs
+++ b/src/isolation/mod.rs
@@ -1,3 +1,4 @@
+pub mod fd;
 pub mod filemap;
 #[cfg(target_os = "linux")]
 pub mod landlock;

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -480,8 +480,14 @@ impl VirtualCPU for KvmCpu {
 								Hypercall::Exit(sysexit) => {
 									return Ok(VcpuStopReason::Exit(sysexit.arg));
 								}
-								Hypercall::FileClose(sysclose) => hypercall::close(sysclose),
-								Hypercall::FileLseek(syslseek) => hypercall::lseek(syslseek),
+								Hypercall::FileClose(sysclose) => hypercall::close(
+									sysclose,
+									&mut self.peripherals.file_mapping.lock().unwrap(),
+								),
+								Hypercall::FileLseek(syslseek) => hypercall::lseek(
+									syslseek,
+									&mut self.peripherals.file_mapping.lock().unwrap(),
+								),
 								Hypercall::FileOpen(sysopen) => hypercall::open(
 									&self.peripherals.mem,
 									sysopen,
@@ -491,11 +497,13 @@ impl VirtualCPU for KvmCpu {
 									&self.peripherals.mem,
 									sysread,
 									self.get_root_pagetable(),
+									&mut self.peripherals.file_mapping.lock().unwrap(),
 								),
 								Hypercall::FileWrite(syswrite) => hypercall::write(
 									&self.peripherals,
 									syswrite,
 									self.get_root_pagetable(),
+									&mut self.peripherals.file_mapping.lock().unwrap(),
 								)?,
 								Hypercall::FileUnlink(sysunlink) => hypercall::unlink(
 									&self.peripherals.mem,

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -294,8 +294,14 @@ impl VirtualCPU for XhyveCpu {
 											&self.peripherals.mem,
 										);
 									}
-									Hypercall::FileClose(sysclose) => hypercall::close(sysclose),
-									Hypercall::FileLseek(syslseek) => hypercall::lseek(syslseek),
+									Hypercall::FileClose(sysclose) => hypercall::close(
+										sysclose,
+										&mut self.peripherals.file_mapping.lock().unwrap(),
+									),
+									Hypercall::FileLseek(syslseek) => hypercall::lseek(
+										syslseek,
+										&mut self.peripherals.file_mapping.lock().unwrap(),
+									),
 									Hypercall::FileOpen(sysopen) => hypercall::open(
 										&self.peripherals.mem,
 										sysopen,
@@ -307,6 +313,7 @@ impl VirtualCPU for XhyveCpu {
 										GuestPhysAddr::new(
 											vcpu.read_system_register(SystemRegister::TTBR0_EL1)?,
 										),
+										&mut self.peripherals.file_mapping.lock().unwrap(),
 									),
 									Hypercall::FileWrite(syswrite) => hypercall::write(
 										&self.peripherals,
@@ -314,6 +321,7 @@ impl VirtualCPU for XhyveCpu {
 										GuestPhysAddr::new(
 											vcpu.read_system_register(SystemRegister::TTBR0_EL1)?,
 										),
+										&mut self.peripherals.file_mapping.lock().unwrap(),
 									)
 									.unwrap(),
 									Hypercall::FileUnlink(sysunlink) => hypercall::unlink(

--- a/tests/test-kernels/src/bin/open_remove_close_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_close_file.rs
@@ -1,0 +1,17 @@
+use std::{
+	fs::{File, remove_file},
+	io::prelude::*,
+};
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	println!("Hello from open_remove_close_file!");
+
+	{
+		let mut file = File::create("/root/foo.txt").unwrap();
+		file.write_all(b"Hello, world!").unwrap();
+		remove_file("/root/foo.txt").unwrap();
+	}
+}

--- a/tests/test-kernels/src/bin/open_remove_close_remove_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_close_remove_file.rs
@@ -1,0 +1,20 @@
+use std::{
+	fs::{File, remove_file},
+	io::prelude::*,
+};
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	println!("Hello from open_remove_close_remove_file!");
+
+	{
+		let mut file = File::create("/root/foo.txt").unwrap();
+		file.write_all(b"Hello, world!").unwrap();
+		remove_file("/root/foo.txt").unwrap();
+	}
+
+	// This is expected to panic.
+	remove_file("/root/foo.txt").unwrap();
+}

--- a/tests/test-kernels/src/bin/open_remove_remove_close_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_remove_close_file.rs
@@ -1,0 +1,20 @@
+use std::{
+	fs::{File, remove_file},
+	io::prelude::*,
+};
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	println!("Hello from open_remove_remove_close_file!");
+
+	{
+		let mut file = File::create("/root/foo.txt").unwrap();
+		file.write_all(b"Hello, world!").unwrap();
+		remove_file("/root/foo.txt").unwrap();
+
+		// This is expected to panic.
+		remove_file("/root/foo.txt").unwrap();
+	}
+}

--- a/tests/test-kernels/src/bin/write_to_fd.rs
+++ b/tests/test-kernels/src/bin/write_to_fd.rs
@@ -1,0 +1,39 @@
+use std::{
+	fs::File,
+	io::Write,
+	mem::forget,
+	os::fd::{AsRawFd, FromRawFd},
+};
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	println!("Hello from write_to_fd!");
+
+	let mut stdout = unsafe { File::from_raw_fd(1) };
+	stdout.write_all(b"Wrote to stdout manually!\n").unwrap();
+	let mut stderr = unsafe { File::from_raw_fd(2) };
+	stderr.write_all(b"Wrote to stderr manually!\n").unwrap();
+
+	// File descriptors above 2 that were not obtained using an open/create hypercall
+	// should not be able to write.
+	let mut file_from_arbitrary_fd = unsafe { File::from_raw_fd(42) };
+	file_from_arbitrary_fd
+		.write_all(b"What?!?!!\n")
+		.expect_err("Could not write to fd 42.");
+
+	{
+		let mut file = File::create("/root/foo.txt").unwrap();
+		file.write_all(b"No! ").unwrap();
+		// Store file descriptor of file before leaking.
+		let fd_leaked = file.as_raw_fd();
+		println!("File descriptor: {fd_leaked}");
+		// Leak the file descriptor.
+		forget(file);
+
+		// Create a new file out of the leaked file descriptor.
+		let mut fd_right = unsafe { File::from_raw_fd(fd_leaked) };
+		fd_right.write_all(b"Nothing is impossible!\n").unwrap();
+	}
+}

--- a/uhyve-interface/src/parameters.rs
+++ b/uhyve-interface/src/parameters.rs
@@ -160,4 +160,5 @@ pub const ALLOWED_OPEN_FLAGS: i32 =
 	O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_TRUNC | O_APPEND | O_DIRECT | O_DIRECTORY;
 
 pub const ENOENT: i32 = 2;
+pub const EBADF: i32 = 9;
 pub const EINVAL: i32 = 22;


### PR DESCRIPTION
This extends UhyveFileMap with a sandbox mapping file descriptors to maps, so as to prevent the opening of file descriptors that belong to Uhyve (or to that of other VMs, when Uhyve exposes such functionality to the user).

This change also introduces a series of test cases for the sandbox, including close / unlink, as well as tests that deliberately use invalid or leaked file descriptors.