### PR TITLE
RfC: chore: add spdx copyright header

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::mem::size_of;
 
 use align_address::Align;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod paging;
 pub(crate) mod registers;
 

--- a/src/arch/x86_64/paging/mod.rs
+++ b/src/arch/x86_64/paging/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use uhyve_interface::GuestPhysAddr;
 use x86_64::{
 	VirtAddr,

--- a/src/arch/x86_64/registers/debug.rs
+++ b/src/arch/x86_64/registers/debug.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Functions to read and write debug registers.
 
 use gdbstub::{stub::SingleThreadStopReason, target::ext::breakpoints::WatchKind};

--- a/src/arch/x86_64/registers/mod.rs
+++ b/src/arch/x86_64/registers/mod.rs
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_os = "linux")]
 pub mod debug;

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![warn(rust_2018_idioms)]
 
 use std::{iter, num::ParseIntError, ops::RangeInclusive, path::PathBuf, process, str::FromStr};

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 pub const PAGE_SIZE: usize = 0x1000;
 pub const GDT_KERNEL_CODE: u16 = 1;
 pub const GDT_KERNEL_DATA: u16 = 2;

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -1,5 +1,6 @@
-//! Flattened Device Trees (FDT).
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Flattened Device Trees (FDT).
 use std::{fmt::Write, ops::Range};
 
 use uhyve_interface::GuestPhysAddr;

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	ffi::{CStr, CString, OsStr},
 	io::{self, Error, ErrorKind},

--- a/src/isolation/fd.rs
+++ b/src/isolation/fd.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	collections::HashSet,
 	os::fd::{FromRawFd, OwnedFd, RawFd},

--- a/src/isolation/filemap.rs
+++ b/src/isolation/filemap.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	collections::HashMap,
 	ffi::{CString, OsString},

--- a/src/isolation/landlock.rs
+++ b/src/isolation/landlock.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	ffi::OsString,
 	io::{Error, ErrorKind},

--- a/src/isolation/mod.rs
+++ b/src/isolation/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 pub mod fd;
 pub mod filemap;
 #[cfg(target_os = "linux")]

--- a/src/isolation/tempdir.rs
+++ b/src/isolation/tempdir.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 use tempfile::{Builder, TempDir};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![warn(rust_2018_idioms)]
 #![allow(unused_macros)]
 #![allow(clippy::missing_safety_doc)]

--- a/src/linux/gdb/breakpoints.rs
+++ b/src/linux/gdb/breakpoints.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::collections::{HashMap, hash_map::Entry};
 
 use gdbstub::target::{self, TargetResult, ext::breakpoints::WatchKind};

--- a/src/linux/gdb/mod.rs
+++ b/src/linux/gdb/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod breakpoints;
 mod regs;
 mod section_offsets;

--- a/src/linux/gdb/regs.rs
+++ b/src/linux/gdb/regs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use gdbstub_arch::x86::reg::{F80, X86_64CoreRegs, X86SegmentRegs, X87FpuInternalRegs};
 use kvm_bindings::{kvm_fpu, kvm_regs, kvm_sregs};
 use kvm_ioctls::VcpuFd;

--- a/src/linux/gdb/section_offsets.rs
+++ b/src/linux/gdb/section_offsets.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use gdbstub::target::{self, ext::section_offsets::Offsets};
 
 use super::GdbUhyve;

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{num::NonZeroU32, sync::Arc};
 
 use kvm_bindings::*;

--- a/src/linux/x86_64/mod.rs
+++ b/src/linux/x86_64/mod.rs
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 pub mod kvm_cpu;

--- a/src/macos/aarch64/mod.rs
+++ b/src/macos/aarch64/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 pub mod vcpu;
 
 /// The size of a page.

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![allow(non_snake_case)]
 #![allow(clippy::identity_op)]
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 macro_rules! align_down {
 	($value:expr, $alignment:expr) => {
 		$value & !($alignment - 1)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{mem::MaybeUninit, ops::Index, os::raw::c_void, ptr::NonNull};
 
 use nix::sys::mman::*;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! General paging related code
 use align_address::Align;
 use thiserror::Error;

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	collections::HashMap,
 	convert::Infallible,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Serial output functionality
 use std::{
 	fs::{File, OpenOptions},

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	collections::HashMap,
 	fmt::Display,

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::num::NonZeroU32;
 
 use crate::stats::CpuStats;

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![cfg_attr(target_os = "macos", allow(dead_code))] // no virtio implementation for macos
 use std::{fmt, mem::size_of, ptr::copy_nonoverlapping, sync::Mutex, vec::Vec};
 
@@ -272,7 +274,7 @@ impl VirtioNetPciDevice {
 				*(dest.as_ptr() as *const u64)
 			});
 			let hva = mem.host_address(gpa).unwrap();
-			let queue = unsafe { Virtqueue::new(hva as *mut u8, QUEUE_LIMIT) };
+			let queue = unsafe { Virtqueue::new(hva as *mut u8, QUEUE_LIMIT };
 			self.virt_queues.push(queue);
 		}
 	}

--- a/src/virtqueue.rs
+++ b/src/virtqueue.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![cfg_attr(target_os = "macos", allow(dead_code))] // no virtio implementation for macos
 use std::{marker::PhantomData, mem, mem::size_of};
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	env, fmt, fs, io,
 	num::NonZeroU32,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	env,
 	fs::remove_file,

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod common;
 
 use std::collections::HashMap;

--- a/tests/fs-test.rs
+++ b/tests/fs-test.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod common;
 
 use std::{

--- a/tests/gdb.rs
+++ b/tests/gdb.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![cfg(target_os = "linux")]
 
 #[allow(dead_code)]

--- a/tests/multicore.rs
+++ b/tests/multicore.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod common;
 
 use byte_unit::{Byte, Unit};

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod common;
 
 use common::{build_hermit_bin, run_simple_vm};

--- a/tests/serial.rs
+++ b/tests/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod common;
 
 use std::fs::read_to_string;

--- a/tests/test-kernels/src/bin/create_file.rs
+++ b/tests/test-kernels/src/bin/create_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{fs::File, io::prelude::*};
 
 #[cfg(target_os = "hermit")]

--- a/tests/test-kernels/src/bin/env.rs
+++ b/tests/test-kernels/src/bin/env.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::env;
 
 #[cfg(target_os = "hermit")]

--- a/tests/test-kernels/src/bin/gdb.rs
+++ b/tests/test-kernels/src/bin/gdb.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
 

--- a/tests/test-kernels/src/bin/multi-thread.rs
+++ b/tests/test-kernels/src/bin/multi-thread.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{hint::black_box, thread, time::Instant};
 
 #[cfg(target_os = "hermit")]

--- a/tests/test-kernels/src/bin/open_close_file.rs
+++ b/tests/test-kernels/src/bin/open_close_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::{File, read_to_string},
 	io::prelude::*,

--- a/tests/test-kernels/src/bin/open_close_remove_file.rs
+++ b/tests/test-kernels/src/bin/open_close_remove_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::{File, read_to_string, remove_file},
 	io::prelude::*,

--- a/tests/test-kernels/src/bin/open_remove_close_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_close_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::{File, remove_file},
 	io::prelude::*,

--- a/tests/test-kernels/src/bin/open_remove_close_remove_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_close_remove_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::{File, remove_file},
 	io::prelude::*,

--- a/tests/test-kernels/src/bin/open_remove_remove_close_file.rs
+++ b/tests/test-kernels/src/bin/open_remove_remove_close_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::{File, remove_file},
 	io::prelude::*,

--- a/tests/test-kernels/src/bin/panic.rs
+++ b/tests/test-kernels/src/bin/panic.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
 

--- a/tests/test-kernels/src/bin/remove_file.rs
+++ b/tests/test-kernels/src/bin/remove_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::fs;
 
 #[cfg(target_os = "hermit")]

--- a/tests/test-kernels/src/bin/serial.rs
+++ b/tests/test-kernels/src/bin/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
 use uhyve_interface::{GuestPhysAddr, HypercallAddress, parameters::SerialWriteBufferParams};

--- a/tests/test-kernels/src/bin/write_to_fd.rs
+++ b/tests/test-kernels/src/bin/write_to_fd.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
 	fs::File,
 	io::Write,


### PR DESCRIPTION
This follows a minimal approach to make it easier for others to reuse Uhyve's components, as well as introduce components from other pieces of software with compatible - but not identical - licensing terms and similar goals (e.g. virtiofsd).

---

This was originally shot down in #693, but I decided to bring this up again with a concretely described proposal.

This was done because I plan to copy some contents of https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/limits.rs?ref_type=heads#L1, which uses a very simplistic type of SPDX header (of course, such a required header could only simply exist in one file):

![image](https://github.com/user-attachments/assets/0a4f87b3-9b75-4b91-85f0-a3290492202a)

I am also raising this again, as I am aware of another project with a compatible license that could stand to benefit from a reusable Landlock component, and might reuse parts of our code.

I made a PR to show what I'm going for because some "license headers" can look worse than others. My original proposal proposed full REUSE compatibility, which I saw as a reason for denial. I was hoping that this version might be more acceptable, see virtiofsd's other copyright headers:

![image](https://github.com/user-attachments/assets/ba2871ec-0228-4d3f-94bc-27cefad31f3c)

![image](https://github.com/user-attachments/assets/772d5b60-e54c-4f14-9033-2f1c4e5f57c4)
