### PR TITLE
chore: add LICENSE-* symlinks in crate directories

### DIFF
--- a/tests/test-kernels/LICENSE-APACHE
+++ b/tests/test-kernels/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/tests/test-kernels/LICENSE-MIT
+++ b/tests/test-kernels/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/uhyve-interface/LICENSE-APACHE
+++ b/uhyve-interface/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/uhyve-interface/LICENSE-MIT
+++ b/uhyve-interface/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Inspired by: https://github.com/rust-vmm/xen/commit/b0ccca7217bfe70c0a49e228886736f9a4f5e98f

---

Feel free to close this if this is seen as redundant.