### PR TITLE
fix(rftrace): fix parameters, allow static mut refs

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -17,22 +17,27 @@ use uhyvelib::{
 };
 
 #[cfg(feature = "instrument")]
+extern crate rftrace as _;
+#[cfg(feature = "instrument")]
+use rftrace_frontend as rftrace;
+
+#[cfg(feature = "instrument")]
 fn setup_trace() {
-	use rftrace_frontend::Events;
+	use rftrace::Events;
 
 	static mut EVENTS: Option<&mut Events> = None;
 
+	#[allow(static_mut_refs)]
 	extern "C" fn dump_trace() {
 		unsafe {
 			if let Some(e) = &mut EVENTS {
-				rftrace_frontend::dump_full_uftrace(e, "uhyve_trace", "uhyve", true)
-					.expect("Saving trace failed");
+				rftrace::dump_full_uftrace(e, "uhyve_trace", "uhyve").expect("Saving trace failed");
 			}
 		}
 	}
 
 	let events = rftrace_frontend::init(1000000, true);
-	rftrace_frontend::enable();
+	rftrace::enable();
 
 	unsafe {
 		EVENTS = Some(events);

--- a/src/isolation/landlock.rs
+++ b/src/isolation/landlock.rs
@@ -283,7 +283,6 @@ where
 {
 	// This segment adds certain paths necessary for Uhyve to function before we
 	// enforce Landlock, such as the kernel path and a couple of paths useful for sysinfo.
-	//
 	// See: https://github.com/GuillaumeGomez/sysinfo/blob/8fd58b8/src/unix/linux/cpu.rs#L420
 	let uhyve_ro_paths = vec![
 		kernel_path.into(),
@@ -291,9 +290,15 @@ where
 		PathBuf::from("/sys/devices/system"),
 		PathBuf::from("/proc/cpuinfo"),
 		PathBuf::from("/proc/stat"),
+		#[cfg(feature = "instrument")]
+		PathBuf::from("/proc/self/maps"),
 	];
 
-	let mut uhyve_rw_paths: Vec<PathBuf> = vec![PathBuf::from("/dev/kvm")];
+	let mut uhyve_rw_paths: Vec<PathBuf> = vec![
+		PathBuf::from("/dev/kvm"),
+		#[cfg(feature = "instrument")]
+		PathBuf::from("./uhyve_trace"),
+	];
 	let mut uhyve_ro_dirs = Vec::new();
 
 	for host_path in host_paths {


### PR DESCRIPTION
This is a WIP: This still doesn't work because of linker-related issues which I am not sure how to fix right now. I presume that this broke because we do not test for `--all-features` (including the `instruments` feature).