### PR TITLE
chore: fix some clippy warnings (27-06-2025)

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -360,11 +360,9 @@ fn run_uhyve() -> i32 {
 	let vm = UhyveVm::new(kernel_path, params).unwrap_or_else(|e| panic!("Error: {e}"));
 
 	let res = vm.run(affinity);
-	if stats {
-		if let Some(stats) = res.stats {
-			println!("Run statistics:");
-			println!("{stats}");
-		}
+	if stats && let Some(stats) = res.stats {
+		println!("Run statistics:");
+		println!("{stats}");
 	}
 	res.code
 }

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -72,7 +72,7 @@ impl Fdt {
 
 	#[cfg(target_arch = "aarch64")]
 	fn cpu(&mut self, id: u32) -> FdtWriterResult<()> {
-		let node_name = format!("cpu@{}", id);
+		let node_name = format!("cpu@{id}");
 
 		let cpu_node = self.writer.begin_node(&node_name)?;
 		self.writer
@@ -85,7 +85,7 @@ impl Fdt {
 
 	#[cfg(target_arch = "aarch64")]
 	fn its(&mut self) -> FdtWriterResult<()> {
-		let node_name = format!("its@{:x}", MSI_BASE_ADDRESS);
+		let node_name = format!("its@{MSI_BASE_ADDRESS:x}");
 		let reg = &[MSI_BASE_ADDRESS, MSI_SIZE.try_into().unwrap()][..];
 
 		let its_node = self.writer.begin_node(&node_name)?;
@@ -138,7 +138,7 @@ impl Fdt {
 
 	#[cfg(target_arch = "aarch64")]
 	pub fn gic(mut self) -> FdtWriterResult<Self> {
-		let node_name = format!("intc@{:x}", GICD_BASE_ADDRESS);
+		let node_name = format!("intc@{GICD_BASE_ADDRESS:x}");
 		let reg = &[
 			GICD_BASE_ADDRESS,
 			GICD_SIZE.try_into().unwrap(),

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -402,14 +402,12 @@ impl VirtualCPU for KvmCpu {
 
 						match port {
 							PCI_CONFIG_DATA_PORT => {
-								if let Some(pci_addr) = self.pci_addr {
-									if pci_addr & 0x1ff800 == 0 {
-										let virtio_device =
-											self.peripherals.virtio_device.lock().unwrap();
-										virtio_device.handle_read(pci_addr & 0x3ff, addr);
-									} else {
-										unsafe { *(addr.as_ptr() as *mut u32) = 0xffffffff };
-									}
+								if let Some(pci_addr) = self.pci_addr
+									&& pci_addr & 0x1ff800 == 0
+								{
+									let virtio_device =
+										self.peripherals.virtio_device.lock().unwrap();
+									virtio_device.handle_read(pci_addr & 0x3ff, addr);
 								} else {
 									unsafe { *(addr.as_ptr() as *mut u32) = 0xffffffff };
 								}
@@ -543,12 +541,12 @@ impl VirtualCPU for KvmCpu {
 							match port {
 								//TODO:
 								PCI_CONFIG_DATA_PORT => {
-									if let Some(pci_addr) = self.pci_addr {
-										if pci_addr & 0x1ff800 == 0 {
-											let mut virtio_device =
-												self.peripherals.virtio_device.lock().unwrap();
-											virtio_device.handle_write(pci_addr & 0x3ff, addr);
-										}
+									if let Some(pci_addr) = self.pci_addr
+										&& pci_addr & 0x1ff800 == 0
+									{
+										let mut virtio_device =
+											self.peripherals.virtio_device.lock().unwrap();
+										virtio_device.handle_write(pci_addr & 0x3ff, addr);
 									}
 								}
 								PCI_CONFIG_ADDRESS_PORT => {

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -339,20 +339,20 @@ impl VirtualCPU for XhyveCpu {
 								#[allow(clippy::match_single_binding)]
 								match addr {
 									_ => {
-										error!("Unable to handle exception {:?}", exception);
+										error!("Unable to handle exception {exception:?}");
 										self.print_registers();
 										return Err(xhypervisor::Error::Error.into());
 									}
 								}
 							}
 						} else {
-							error!("Unsupported exception class: 0x{:x}", ec);
+							error!("Unsupported exception class: 0x{ec:x}");
 							self.print_registers();
 							return Err(xhypervisor::Error::Error.into());
 						}
 					}
 					_ => {
-						error!("Unknown exit reason: {:?}", reason);
+						error!("Unknown exit reason: {reason:?}");
 						return Err(xhypervisor::Error::Error.into());
 					}
 				}
@@ -381,7 +381,7 @@ impl VirtualCPU for XhyveCpu {
 
 	fn print_registers(&self) {
 		if let Some(vcpu) = &self.vcpu {
-			println!("{:?}", vcpu);
+			println!("{vcpu:?}");
 		}
 	}
 

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -100,6 +100,7 @@ impl MmapMemory {
 	/// This is unsafe, as can create multiple aliasing. During the lifetime of
 	/// the returned slice, the memory must not be altered to prevent undfined
 	/// behaviour.
+	#[allow(clippy::mut_from_ref)]
 	pub unsafe fn slice_at(&self, addr: GuestPhysAddr, len: usize) -> Result<&[u8], MemoryError> {
 		if addr.as_u64() as usize + len >= self.memory_size + self.guest_address.as_u64() as usize {
 			Err(MemoryError::BoundsViolation)
@@ -115,6 +116,7 @@ impl MmapMemory {
 	/// This is unsafe, as it can create multiple aliasing. During the lifetime of
 	/// the returned slice, the memory must not be altered to prevent undfined
 	/// behavior.
+	#[allow(clippy::mut_from_ref)]
 	pub unsafe fn slice_at_mut(
 		&self,
 		addr: GuestPhysAddr,
@@ -155,6 +157,7 @@ impl MmapMemory {
 	}
 
 	/// Get a mutable reference to the type at the given address in the memory.
+	#[allow(clippy::mut_from_ref)]
 	pub unsafe fn get_ref_mut<T>(&self, addr: GuestPhysAddr) -> Result<&mut T, MemoryError> {
 		Ok(unsafe { &mut *(self.host_address(addr)? as *mut T) })
 	}


### PR DESCRIPTION
Some warnings involving #[deny(clippy::mut_from_ref)] still not fixed.