### PR TITLE
refactor(arch/x86_64): get rid of unnecessary .try_into().unwrap()

### DIFF
--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -99,7 +99,7 @@ mod tests {
 		println!("mmap memory created {mem:x?}");
 
 		init_guest_mem(
-			unsafe { mem.as_slice_mut() }.try_into().unwrap(),
+			unsafe { mem.as_slice_mut() },
 			guest_address,
 			MIN_PHYSMEM_SIZE as u64 * 2,
 			false,


### PR DESCRIPTION
cherry-picked from https://github.com/hermit-os/uhyve/pull/1005
