### PR TITLE
refactor: introduce params::FileMappings

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 #[cfg(target_os = "linux")]
 use uhyvelib::params::FileSandboxMode;
 use uhyvelib::{
-	params::{CpuCount, EnvVars, GuestMemorySize, Output, Params},
+	params::{CpuCount, EnvVars, FileMappings, GuestMemorySize, Output, Params},
 	vm::UhyveVm,
 };
 
@@ -315,7 +315,7 @@ impl From<Args> for Params {
 			cpu_count,
 			#[cfg(target_os = "linux")]
 			pit,
-			file_mapping,
+			file_mapping: FileMappings::try_from(file_mapping.as_slice()).unwrap(),
 			#[cfg(target_os = "linux")]
 			gdb_port,
 			#[cfg(target_os = "macos")]

--- a/src/isolation/mod.rs
+++ b/src/isolation/mod.rs
@@ -4,34 +4,6 @@ pub mod filemap;
 pub mod landlock;
 pub mod tempdir;
 
-use std::{
-	fs::canonicalize,
-	io::ErrorKind,
-	path::{PathBuf, absolute},
-};
-
-use clean_path::clean;
-
-/// Separates a string of the format "./host_dir/host_path.txt:guest_path.txt"
-/// into a guest_path (String) and host_path (OsString) respectively.
-///
-/// * `mapping` - A mapping of the format `./host_path.txt:guest.txt`.
-fn split_guest_and_host_path(mapping: &str) -> Result<(PathBuf, PathBuf), ErrorKind> {
-	let mut mappingiter = mapping.split(':');
-	let host_str = mappingiter.next().ok_or(ErrorKind::InvalidInput)?;
-	let guest_str = mappingiter.next().ok_or(ErrorKind::InvalidInput)?;
-
-	// TODO: Replace clean-path in favor of Path::normalize_lexically, which has not
-	// been implemented yet. See: https://github.com/rust-lang/libs-team/issues/396
-	let host_path =
-		canonicalize(host_str).map_or_else(|_| clean(absolute(host_str).unwrap()), clean);
-
-	// `.to_str().unwrap()` should never fail because `guest_str` is always valid UTF-8
-	let guest_path = PathBuf::from(clean(guest_str).to_str().unwrap());
-
-	Ok((guest_path, host_path))
-}
-
 #[test]
 fn test_split_guest_and_host_path() {
 	use std::path::PathBuf;

--- a/src/isolation/tempdir.rs
+++ b/src/isolation/tempdir.rs
@@ -17,7 +17,8 @@ pub fn create_temp_dir(dir_path: &Option<String>) -> TempDir {
 				.map(PathBuf::from)
 				.unwrap_or_else(env::temp_dir),
 		)
-		.expect("The temporary directory could not be created.");
+		.ok()
+		.unwrap_or_else(|| panic!("The temporary directory could not be created."));
 
 	assert!(!dir.path().metadata().unwrap().permissions().readonly());
 

--- a/tests/fs-test.rs
+++ b/tests/fs-test.rs
@@ -12,7 +12,7 @@ use common::{
 	build_hermit_bin, check_result, get_fs_fixture_path, remove_file_if_exists, run_vm_in_thread,
 };
 use rand::{Rng, distr::Alphanumeric};
-use uhyvelib::params::Params;
+use uhyvelib::params::{FileMappings, Params};
 
 /// Verifies successful file creation on the host OS and its contents.
 pub fn verify_file_equals(testfile: &PathBuf, contents: &str) {
@@ -70,8 +70,12 @@ fn get_testname_derived_guest_path(test_name: &str) -> PathBuf {
 }
 
 // Creates a vector out of a given host path and guest path for UhyveFileMap.
-fn create_filemap_params<T: AsStr, U: AsStr>(host_path: T, guest_path: U) -> Vec<String> {
-	vec![format!("{}:{}", host_path.as_str(), guest_path.as_str())]
+fn create_filemap_params<T: AsStr, U: AsStr>(host_path: T, guest_path: U) -> FileMappings {
+	FileMappings::try_from(vec![format!(
+		"{}:{}",
+		host_path.as_str(),
+		guest_path.as_str()
+	)])
 }
 
 /// Creates kernel arguments for fs-tests.


### PR DESCRIPTION
This decouples Uhyve's internal UhyveFileMap from the format of the CLI parameters, and follows a similar approach to `EnvVars`.

We use a HashMap that is copied here - that is subject to change (as the HashMap is not exposed to the VM itself, a vector might suffice?). Tests still need adjustment. `self.files.0` is a bit ugly.