### PR TITLE
chore: prefer expect attr and reasons

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -32,9 +32,9 @@ pub const PT_SELF: u64 = 1 << 55;
 /*
  * Memory types available.
  */
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const MT_DEVICE_nGnRnE: u64 = 0;
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const MT_DEVICE_nGnRE: u64 = 1;
 pub const MT_DEVICE_GRE: u64 = 2;
 pub const MT_NORMAL_NC: u64 = 3;

--- a/src/arch/x86_64/paging/mod.rs
+++ b/src/arch/x86_64/paging/mod.rs
@@ -133,8 +133,8 @@ pub fn initialize_pagetables(
 	}
 }
 
-#[allow(dead_code)]
 /// Helper fn for debugging pagetables
+#[allow(dead_code, reason = "Useful for debugging purposes.")]
 fn pretty_print_pagetable(pt: &PageTable) {
 	println!(
 		"Idx       Address          Idx       Address          Idx       Address          Idx       Address      "

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -27,7 +27,10 @@ use crate::{
 
 pub struct XhyveVm {
 	peripherals: Arc<VmPeripherals>,
-	#[allow(dead_code)]
+	#[expect(
+		dead_code,
+		reason = "Gic should be created and stored throughout the struct's lifetime, not used actively"
+	)]
 	gic: Gic,
 }
 impl VirtualizationBackendInternal for XhyveVm {
@@ -180,7 +183,7 @@ impl VirtualCPU for XhyveCpu {
 			   - Fill in the missing Documentation for some of the bits and verify if we care about them
 				 or if loading and not setting them would be the appropriate action.
 		*/
-		#[allow(clippy::identity_op)]
+		#[expect(clippy::identity_op)]
 		let sctrl_el1: u64 = 0
 		 | (1 << 26) 	    /* UCI	Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
 									DC CVAC and IC IVAU instructions */

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -79,7 +79,7 @@ impl MmapMemory {
 	/// # Safety
 	///
 	/// This can create multiple aliasing. During the lifetime of the returned slice, the memory must not be altered, dropped or simmilar.
-	#[allow(clippy::mut_from_ref)]
+	#[expect(clippy::mut_from_ref)]
 	pub unsafe fn as_slice_mut(&self) -> &mut [u8] {
 		unsafe { std::slice::from_raw_parts_mut(self.host_address, self.memory_size) }
 	}
@@ -87,7 +87,7 @@ impl MmapMemory {
 	/// # Safety
 	///
 	/// Same as [`as_slice_mut`], but for `MaybeUninit<u8>`. Actually the memory is initialized, as Mmap zero initializes it, but some fns like [`hermit_entry::elf::load_kernel`] require [`MaybeUninit`]s.
-	#[allow(clippy::mut_from_ref)]
+	#[expect(clippy::mut_from_ref)]
 	pub unsafe fn as_slice_uninit_mut(&self) -> &mut [MaybeUninit<u8>] {
 		unsafe {
 			std::slice::from_raw_parts_mut(
@@ -119,7 +119,7 @@ impl MmapMemory {
 	/// This is unsafe, as it can create multiple aliasing. During the lifetime of
 	/// the returned slice, the memory must not be altered to prevent undfined
 	/// behavior.
-	#[allow(clippy::mut_from_ref)]
+	#[expect(clippy::mut_from_ref)]
 	pub unsafe fn slice_at_mut(
 		&self,
 		addr: GuestPhysAddr,
@@ -164,7 +164,7 @@ impl MmapMemory {
 	/// # Safety
 	///
 	/// Get a mutable reference to the type at the given address in the memory.
-	#[allow(clippy::mut_from_ref)]
+	#[expect(clippy::mut_from_ref)]
 	pub unsafe fn get_ref_mut<T>(&self, addr: GuestPhysAddr) -> Result<&mut T, MemoryError> {
 		Ok(unsafe { &mut *(self.host_address(addr)? as *mut T) })
 	}
@@ -198,13 +198,19 @@ impl Index<usize> for MmapMemory {
 /// Wrapper aroud a memory allocation that is aligned to x86 HugePages
 /// (`0x20_0000`). Intended for testing purposes only
 #[cfg(test)]
-#[allow(dead_code)]
+#[expect(
+	dead_code,
+	reason = "Part of ongoing work-in-progress virtio-net feature"
+)]
 pub(crate) struct HugePageAlignedMem<'a, const SIZE: usize> {
 	ptr: *mut u8,
 	pub mem: &'a mut [u8],
 }
 #[cfg(test)]
-#[allow(dead_code)]
+#[expect(
+	dead_code,
+	reason = "Part of ongoing work-in-progress virtio-net feature"
+)]
 impl<const SIZE: usize> HugePageAlignedMem<'_, SIZE> {
 	pub fn new() -> Self {
 		use std::alloc::{Layout, alloc_zeroed};

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -5,7 +5,10 @@ use crate::stats::CpuStats;
 use crate::{HypervisorResult, os::DebugExitInfo};
 
 /// Reasons for vCPU exits.
-#[allow(dead_code, reason = "Not all variants are used by all targets")]
+#[cfg_attr(
+	target_os = "macos",
+	expect(dead_code, reason = "Not all variants used in macOS.")
+)]
 pub enum VcpuStopReason {
 	/// The vCPU stopped for debugging.
 	Debug(DebugExitInfo),
@@ -26,7 +29,6 @@ pub trait VirtualCPU: Sized + Send {
 	fn run(&mut self) -> HypervisorResult<(Option<i32>, Option<CpuStats>)>;
 
 	/// Prints the VCPU's registers to stdout.
-	#[allow(dead_code)]
 	fn print_registers(&self);
 
 	/// Queries the CPUs base frequency in kHz

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -82,7 +82,7 @@ macro_rules! write_u16 {
 	};
 }
 
-#[allow(unused_macros)]
+#[expect(unused_macros)]
 macro_rules! read_u32 {
 	($registers:expr, $address:expr) => {
 		($registers[$address] as u32)
@@ -92,7 +92,7 @@ macro_rules! read_u32 {
 	};
 }
 
-#[allow(unused_macros)]
+#[expect(unused_macros)]
 macro_rules! write_u32 {
 	($registers:expr, $address:expr, $value:expr) => {
 		$registers[$address] = ($value & 0xFF) as u8;
@@ -257,7 +257,7 @@ impl VirtioNetPciDevice {
 
 	pub fn write_selected_queue(&mut self, dest: &[u8]) {
 		self.selected_queue_num = unsafe {
-			#[allow(clippy::cast_ptr_alignment)]
+			#[expect(clippy::cast_ptr_alignment)]
 			*(dest.as_ptr() as *const u16)
 		};
 	}
@@ -270,7 +270,7 @@ impl VirtioNetPciDevice {
 			&& self.selected_queue_num as usize == self.virt_queues.len()
 		{
 			let gpa = GuestPhysAddr::new(unsafe {
-				#[allow(clippy::cast_ptr_alignment)]
+				#[expect(clippy::cast_ptr_alignment)]
 				*(dest.as_ptr() as *const u64)
 			});
 			let hva = mem.host_address(gpa).unwrap();
@@ -282,7 +282,7 @@ impl VirtioNetPciDevice {
 	pub fn write_requested_features(&mut self, dest: &[u8]) {
 		if self.read_status_reg() == STATUS_ACKNOWLEDGE | STATUS_DRIVER {
 			let requested_features = unsafe {
-				#[allow(clippy::cast_ptr_alignment)]
+				#[expect(clippy::cast_ptr_alignment)]
 				*(dest.as_ptr() as *const u32)
 			};
 			self.requested_features =

--- a/src/virtqueue.rs
+++ b/src/virtqueue.rs
@@ -28,14 +28,14 @@ impl<T> Vring<T> {
 
 	pub fn _flags(&self) -> u16 {
 		unsafe {
-			#[allow(clippy::cast_ptr_alignment)]
+			#[expect(clippy::cast_ptr_alignment)]
 			*(self.mem as *const u16)
 		}
 	}
 
 	pub fn index(&self) -> u16 {
 		unsafe {
-			#[allow(clippy::cast_ptr_alignment)]
+			#[expect(clippy::cast_ptr_alignment)]
 			*(self.mem.offset(2) as *const u16)
 		}
 	}
@@ -43,7 +43,7 @@ impl<T> Vring<T> {
 	pub fn advance_index(&mut self) {
 		unsafe {
 			let new_value = self.index() + 1;
-			#[allow(clippy::cast_ptr_alignment)]
+			#[expect(clippy::cast_ptr_alignment)]
 			let write_ptr = self.mem.offset(2) as *mut u16;
 			*write_ptr = new_value;
 		}
@@ -69,7 +69,7 @@ pub struct Virtqueue {
 	pub available_ring: VringAvailable,
 	pub used_ring: VringUsed,
 	pub last_seen_available: u16,
-	#[allow(dead_code)]
+	#[expect(dead_code)]
 	pub last_seen_used: u16,
 	pub queue_size: u16,
 }
@@ -111,7 +111,7 @@ fn get_used_ring_offset() -> usize {
 
 impl Virtqueue {
 	pub unsafe fn new(mem: *mut u8, queue_size: usize) -> Self {
-		#[allow(clippy::cast_ptr_alignment)]
+		#[expect(clippy::cast_ptr_alignment)]
 		let descriptor_table = mem as *mut VringDescriptor;
 		let available_ring_ptr = unsafe { mem.add(get_available_ring_offset()) };
 		let used_ring_ptr = unsafe { mem.add(get_used_ring_offset()) };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -118,7 +118,7 @@ pub(crate) struct KernelInfo {
 	/// The first instruction after boot
 	pub entry_point: GuestPhysAddr,
 	/// The starting position of the image in physical memory
-	#[cfg_attr(target_os = "macos", allow(dead_code))] // currently only needed in gdb
+	#[cfg_attr(target_os = "macos", expect(dead_code))] // currently only needed in gdb
 	pub kernel_address: GuestPhysAddr,
 	pub params: Params,
 	pub path: PathBuf,
@@ -493,9 +493,12 @@ fn write_boot_info_to_mem(
 		hardware_info: HardwareInfo {
 			phys_addr_range: mem.guest_address.as_u64()
 				..mem.guest_address.as_u64() + mem.memory_size as u64,
-			#[allow(
-				clippy::useless_conversion,
-				reason = "aarch64 uses 64-bit SerialPortBase, x86_64 uses 16 bit"
+			#[cfg_attr(
+				target_arch = "x86_64",
+				expect(
+					clippy::useless_conversion,
+					reason = "aarch64 uses 64-bit SerialPortBase, x86_64 uses 16 bit"
+				)
 			)]
 			serial_port_base: SerialPortBase::new(
 				(uhyve_interface::HypercallAddress::Uart as u16).into(),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,8 @@
-#![allow(dead_code)] // Not all functions here are used in all tests
+#![allow(
+	dead_code,
+	reason = "Many helper functions are not used in every test."
+)]
+
 use std::{
 	env,
 	fs::remove_file,
@@ -47,7 +51,6 @@ pub fn build_hermit_bin(kernel: impl AsRef<Path> + std::fmt::Display) -> PathBuf
 
 /// Small wrapper around [`Uhyve::run`] with default parameters for a small and
 /// simple Uhyve vm
-#[allow(dead_code)]
 pub fn run_simple_vm(kernel_path: PathBuf) -> VmResult {
 	env_logger::try_init().ok();
 	println!("Launching kernel {}", kernel_path.display());


### PR DESCRIPTION
This is done anywhere apart from architecture-specific and test code. Some unnecessary attributes were discovered and removed as well.

Reasons were added to all found instances of allow attributes, although we cannot enforce this only for allow using clippy::allow_attributes_without_reason as this lint affects both allow and expect attributes.

An attribute that explicitly allows the allow attribute was added for src/arch/mod.rs and tests/common.rs, as using allow is totally fine there. Nevertheless, I added reasons for allow attributes inside of the tests, because more documentation can't hurt (and we were already doing this for a gdb function).