### PR TITLE
ci: skip for markdown and image files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.png"
+      - "**.svg"
   merge_group:
 
 jobs:


### PR DESCRIPTION
This prevents unnecessary CI runs if the files themselves don't actually need to be checked using the CI. Mostly useful for doc updates.