### PR TITLE
feat: add TOML configuration for Uhyve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e520ba58faea3487f75df198b1d079644ec226ea3b0507d002c6fa4b8cf93a"
+dependencies = [
+ "merge_derive",
+ "num-traits",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f8ce6efff81cbc83caf4af0905c46e58cb46892f63ad3835e81b47eaf7968"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1066,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1345,18 +1389,18 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1372,6 +1416,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
  "serde",
 ]
 
@@ -1525,10 +1578,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1537,9 +1614,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.8",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tun-tap"
@@ -1574,17 +1666,20 @@ dependencies = [
  "log",
  "mac_address",
  "memory_addresses",
+ "merge",
  "nix 0.30.1",
  "rand 0.9.2",
  "raw-cpuid 11.5.0",
  "regex",
  "rftrace",
  "rftrace-frontend",
+ "serde",
  "shell-words",
  "sysinfo",
  "tempfile",
  "thiserror",
  "time",
+ "toml",
  "tun-tap",
  "uhyve-interface",
  "uuid",
@@ -1973,9 +2068,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ instrument = ["rftrace", "rftrace-frontend"]
 
 [dependencies]
 align-address = "0.3.0"
-byte-unit = { version = "5", features = ["byte"] }
+byte-unit = { version = "5", features = ["byte", "serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 clean-path = "0.2.1"
 core_affinity = "0.8"
@@ -69,6 +69,9 @@ sysinfo = { version = "0.36.1", default-features = false, features = ["system"] 
 vm-fdt = "0.3"
 tempfile = "3.20.0"
 uuid = { version = "1.17.0", features = ["fast-rng", "v4"]}
+toml = "0.9.5"
+serde = { version = "1.0", features = ["derive"] }
+merge = { version = "0.2" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = "0.13"

--- a/data/sample_config.toml
+++ b/data/sample_config.toml
@@ -1,0 +1,25 @@
+# This is a ready-to-use sample configuration used for Uhyve.
+# Some settings that may be undesirable were commented out deliberately.
+#
+# Feel free to adjust it or use it as-is.
+
+[uhyve]
+# output = "test.txt"
+stats = true
+# tempdir = "/tmp"
+file_isolation = "strict"
+# gdb_port = 1
+
+[memory]
+memory_size = '100MiB'
+no_aslr = true
+thp = true
+ksm = true
+
+[cpu]
+cpu_count = 4
+affinity = [1, 2, 3, 4]
+pit = true
+
+[guest]
+env_vars = ['foo=bar']

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -7,6 +7,8 @@ use core_affinity::CoreId;
 use either::Either;
 use env_logger::Builder;
 use log::LevelFilter;
+use merge::Merge;
+use serde::Deserialize;
 use thiserror::Error;
 #[cfg(target_os = "linux")]
 use uhyvelib::params::FileSandboxMode;
@@ -39,35 +41,48 @@ fn setup_trace() {
 	}
 }
 
-/// Used by clap to derive CLI parameters for Uhyve.
-#[derive(Parser, Debug)]
+/// Used by clap to derive CLI parameters for Uhyve, as well as
+/// by the TOML extension to derive a _subset_ of the CLI arguments.
+#[derive(Debug, Default, Deserialize, Merge, Parser)]
 #[clap(version, author, about)]
+#[serde(default)]
 struct Args {
 	#[clap(flatten, next_help_heading = "Uhyve OPTIONS")]
-	uhyve_args: UhyveArgs,
+	uhyve: UhyveArgs,
 
 	#[clap(flatten, next_help_heading = "Memory OPTIONS")]
-	memory_args: MemoryArgs,
+	memory: MemoryArgs,
 
 	#[clap(flatten, next_help_heading = "Cpu OPTIONS")]
-	cpu_args: CpuArgs,
+	cpu: CpuArgs,
 
 	#[clap(flatten, next_help_heading = "Guest OPTIONS")]
-	guest_args: GuestArgs,
+	guest: GuestArgs,
+}
+
+impl Args {
+	pub fn get_config_file(&self) -> Option<&PathBuf> {
+		self.uhyve.config.as_ref()
+	}
 }
 
 /// Arguments for Uhyve runtime-related configurations.
-#[derive(Parser, Debug)]
+#[derive(Debug, Default, Deserialize, Merge, Parser)]
+#[serde(default)]
 struct UhyveArgs {
 	/// Kernel output redirection.
 	///
 	/// None discards all output, Omit for stdout
 	#[clap(short, long, value_name = "FILE")]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	output: Option<String>,
 
 	/// Display statistics after the execution
-	#[clap(long)]
-	stats: bool,
+	#[clap(long, action = clap::ArgAction::SetTrue)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	stats: Option<bool>,
 
 	/// Paths that the kernel should be able to view, read or write.
 	///
@@ -75,6 +90,8 @@ struct UhyveArgs {
 	///
 	/// Example: --file-mapping host_dir:guest_dir --file-mapping file.txt:guest_file.txt
 	#[clap(long)]
+	#[serde(skip)]
+	#[merge(strategy = merge::vec::append)]
 	file_mapping: Vec<String>,
 
 	/// The path that should be used for temporary directories storing unmapped files.
@@ -85,6 +102,8 @@ struct UhyveArgs {
 	///
 	/// Defaults to /tmp.
 	#[clap(long)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	tempdir: Option<String>,
 
 	/// File isolation (none, normal, strict)
@@ -98,6 +117,8 @@ struct UhyveArgs {
 	///
 	/// [default: normal]
 	#[clap(long)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	#[cfg(target_os = "linux")]
 	file_isolation: Option<String>,
 
@@ -105,38 +126,117 @@ struct UhyveArgs {
 	///
 	/// Starts a GDB server on the provided port and waits for a connection.
 	#[clap(short = 's', long, env = "HERMIT_GDB_PORT")]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	#[cfg(target_os = "linux")]
 	gdb_port: Option<u16>,
+
+	/// TOML configuration file
+	///
+	/// Reads configurations from a locally given path.
+	#[clap(long, env = "HERMIT_CONFIG")]
+	#[serde(skip)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	pub config: Option<PathBuf>,
 }
 
 /// Arguments for memory resources allocated to the guest (both guest and host).
-#[derive(Parser, Debug)]
-struct MemoryArgs {
+#[derive(Debug, Default, Deserialize, Merge, Parser)]
+#[serde(default)]
+pub struct MemoryArgs {
 	/// Guest RAM size
-	#[clap(short = 'm', long, default_value_t, env = "HERMIT_MEMORY_SIZE")]
-	memory_size: GuestMemorySize,
+	#[clap(short = 'm', long, env = "HERMIT_MEMORY_SIZE")]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	memory_size: Option<GuestMemorySize>,
 
 	/// Disable ASLR
-	#[clap(long)]
-	no_aslr: bool,
+	#[clap(long, action = clap::ArgAction::SetTrue)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	no_aslr: Option<bool>,
 
 	/// Transparent Hugepages
 	///
 	/// Advise the kernel to enable Transparent Hugepages [THP] on the virtual RAM.
 	///
 	/// [THP]: https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html
-	#[clap(long)]
+	#[clap(long, action = clap::ArgAction::SetTrue)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	#[cfg(target_os = "linux")]
-	thp: bool,
+	thp: Option<bool>,
 
 	/// Kernel Samepage Merging
 	///
 	/// Advise the kernel to enable Kernel Samepage Merging [KSM] on the virtual RAM.
 	///
 	/// [KSM]: https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html
-	#[clap(long)]
+	#[clap(long, action = clap::ArgAction::SetTrue)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
 	#[cfg(target_os = "linux")]
-	ksm: bool,
+	ksm: Option<bool>,
+}
+
+/// Arguments for the CPU resources allocated to the guest.
+#[derive(Clone, Debug, Default, Deserialize, Merge, Parser)]
+#[serde(default)]
+struct CpuArgs {
+	/// Number of guest CPUs
+	#[clap(short, long, env = "HERMIT_CPU_COUNT")]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	cpu_count: Option<CpuCount>,
+
+	/// Create a PIT
+	#[clap(long, action = clap::ArgAction::SetTrue)]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	#[cfg(target_os = "linux")]
+	pit: Option<bool>,
+
+	/// Bind guest vCPUs to host cpus
+	///
+	/// A list of host CPU numbers onto which the guest vCPUs should be bound to obtain performance benefits.
+	/// List items may be single numbers or inclusive ranges.
+	/// List items may be separated with commas or spaces.
+	///
+	/// # Examples
+	///
+	/// * `--affinity "0 1 2"`
+	///
+	/// * `--affinity 0-1,2`
+	#[clap(short, long, name = "CPUs")]
+	#[serde(default)]
+	#[merge(strategy = merge::option::overwrite_none)]
+	affinity: Option<Affinity>,
+}
+
+impl CpuArgs {
+	fn get_affinity(self, app: &mut Command) -> Option<Vec<CoreId>> {
+		self.affinity.map(|affinity| {
+			let affinity_num_vals = affinity.0.len();
+			let cpus_num_vals = usize::try_from(self.cpu_count.unwrap_or_default().get()).unwrap();
+			if affinity_num_vals != cpus_num_vals {
+				let affinity_arg = app
+					.get_arguments()
+					.find(|arg| arg.get_id() == "affinity")
+					.unwrap();
+				let cpus_arg = app
+					.get_arguments()
+					.find(|arg| arg.get_id() == "cpus")
+					.unwrap();
+				let verb = if affinity_num_vals > 1 { "were" } else { "was" };
+				let message = format!(
+					"The argument '{affinity_arg}' requires {cpus_num_vals} values (matching '{cpus_arg}'), but {affinity_num_vals} {verb} provided",
+				);
+				app.error(ErrorKind::WrongNumberOfValues, message).exit()
+			} else {
+				affinity.0
+			}
+		})
+	}
 }
 
 #[derive(Debug, Clone)]
@@ -219,68 +319,57 @@ impl FromStr for Affinity {
 	}
 }
 
-/// Arguments for the CPU resources allocated to the guest.
-#[derive(Parser, Debug, Clone)]
-struct CpuArgs {
-	/// Number of guest CPUs
-	#[clap(short, long, default_value_t, env = "HERMIT_CPU_COUNT")]
-	cpu_count: CpuCount,
+struct AffinityVisitor;
 
-	/// Create a PIT
-	#[clap(long)]
-	#[cfg(target_os = "linux")]
-	pit: bool,
+impl<'de> serde::de::Visitor<'de> for AffinityVisitor {
+	type Value = Affinity;
 
-	/// Bind guest vCPUs to host cpus
-	///
-	/// A list of host CPU numbers onto which the guest vCPUs should be bound to obtain performance benefits.
-	/// List items may be single numbers or inclusive ranges.
-	/// List items may be separated with commas or spaces.
-	///
-	/// # Examples
-	///
-	/// * `--affinity "0 1 2"`
-	///
-	/// * `--affinity 0-1,2`
-	#[clap(short, long, name = "CPUs")]
-	affinity: Option<Affinity>,
+	fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		formatter.write_str("an Affinity, e.g. \"1-3,5\" or [1,2,3,5]")
+	}
+
+	fn visit_str<E>(self, s: &str) -> Result<Affinity, E>
+	where
+		E: serde::de::Error,
+	{
+		s.parse()
+			.map_err(|_| serde::de::Error::invalid_value(serde::de::Unexpected::Str(s), &self))
+	}
+
+	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+	where
+		A: serde::de::SeqAccess<'de>,
+	{
+		let mut values = Vec::<CoreId>::new();
+		while let Some(value) = seq.next_element()? {
+			values.push(CoreId { id: value });
+		}
+		Ok(Affinity(values))
+	}
 }
 
-impl CpuArgs {
-	fn get_affinity(self, app: &mut Command) -> Option<Vec<CoreId>> {
-		self.affinity.map(|affinity| {
-			let affinity_num_vals = affinity.0.len();
-			let cpus_num_vals = usize::try_from(self.cpu_count.get()).unwrap();
-			if affinity_num_vals != cpus_num_vals {
-				let affinity_arg = app
-					.get_arguments()
-					.find(|arg| arg.get_id() == "affinity")
-					.unwrap();
-				let cpus_arg = app
-					.get_arguments()
-					.find(|arg| arg.get_id() == "cpus")
-					.unwrap();
-				let verb = if affinity_num_vals > 1 { "were" } else { "was" };
-				let message = format!(
-					"The argument '{affinity_arg}' requires {cpus_num_vals} values (matching '{cpus_arg}'), but {affinity_num_vals} {verb} provided",
-				);
-				app.error(ErrorKind::WrongNumberOfValues, message).exit()
-			} else {
-				affinity.0
-			}
-		})
+impl<'de> serde::de::Deserialize<'de> for Affinity {
+	fn deserialize<D>(deserializer: D) -> Result<Affinity, D::Error>
+	where
+		D: serde::de::Deserializer<'de>,
+	{
+		deserializer.deserialize_any(AffinityVisitor)
 	}
 }
 
 /// Arguments for the guest OS and guest runtime-related configurations.
-#[derive(Parser, Debug)]
+#[derive(Debug, Default, Deserialize, Merge, Parser)]
 struct GuestArgs {
 	/// The kernel to execute
 	#[clap(value_parser)]
+	#[serde(skip)]
+	#[merge(skip)]
 	kernel: PathBuf,
 
 	/// Arguments to forward to the kernel
-	kernel_args: Vec<String>,
+	#[serde(skip)]
+	#[merge(skip)]
+	pub kernel_args: Vec<String>,
 
 	/// Environment variables of the guest as env=value paths
 	///
@@ -288,13 +377,15 @@ struct GuestArgs {
 	///
 	/// Example: --env_vars ASDF=jlk -e TERM=uhyveterm2000
 	#[clap(short, long)]
-	env_vars: Vec<String>,
+	#[serde(default)]
+	#[merge(strategy = merge::vec::append)]
+	pub env_vars: Vec<String>,
 }
 
 impl From<Args> for Params {
 	fn from(args: Args) -> Self {
 		let Args {
-			uhyve_args:
+			uhyve:
 				UhyveArgs {
 					output,
 					stats,
@@ -304,8 +395,9 @@ impl From<Args> for Params {
 					file_isolation,
 					#[cfg(target_os = "linux")]
 					gdb_port,
+					config: _,
 				},
-			memory_args:
+			memory:
 				MemoryArgs {
 					memory_size,
 					no_aslr,
@@ -314,29 +406,29 @@ impl From<Args> for Params {
 					#[cfg(target_os = "linux")]
 					ksm,
 				},
-			cpu_args:
+			cpu:
 				CpuArgs {
 					cpu_count,
 					#[cfg(target_os = "linux")]
 					pit,
 					affinity: _,
 				},
-			guest_args: GuestArgs {
+			guest: GuestArgs {
 				kernel: _,
 				kernel_args,
 				env_vars,
 			},
 		} = args;
 		Self {
-			memory_size,
+			memory_size: memory_size.unwrap_or_default(),
 			#[cfg(target_os = "linux")]
-			thp,
+			thp: thp.unwrap_or_default(),
 			#[cfg(target_os = "linux")]
-			ksm,
-			aslr: !no_aslr,
-			cpu_count,
+			ksm: ksm.unwrap_or_default(),
+			aslr: !no_aslr.unwrap_or_default(),
+			cpu_count: cpu_count.unwrap_or_default(),
 			#[cfg(target_os = "linux")]
-			pit,
+			pit: pit.unwrap_or_default(),
 			file_mapping,
 			#[cfg(target_os = "linux")]
 			gdb_port,
@@ -356,7 +448,7 @@ impl From<Args> for Params {
 			} else {
 				Output::StdIo
 			},
-			stats,
+			stats: stats.unwrap_or_default(),
 			env: EnvVars::try_from(env_vars.as_slice()).unwrap(),
 		}
 	}
@@ -366,6 +458,14 @@ fn run_uhyve() -> i32 {
 	#[cfg(feature = "instrument")]
 	setup_trace();
 
+	/*
+	 * 1. CLI parameters are parsed into Args.
+	 * 2. Get config file location using the CLI parameters' config.
+	 * 3. Override missing CLI configs ("None") with configs obtained from config file.
+	 *
+	 * (Done wherever the user has not explicitly defined an option using the CLI)
+	 */
+
 	let mut env_builder = Builder::new();
 	env_builder.filter_level(LevelFilter::Warn);
 	env_builder.parse_env("RUST_LOG");
@@ -373,10 +473,24 @@ fn run_uhyve() -> i32 {
 	env_builder.init();
 
 	let mut app = Args::command();
-	let args = Args::parse();
-	let stats = args.uhyve_args.stats;
-	let kernel_path = args.guest_args.kernel.clone();
-	let affinity = args.cpu_args.clone().get_affinity(&mut app);
+	let mut args = Args::parse();
+	// Tries to read arguments from a configuration file. If it doesn't exist or if
+	// parsing is not possible, continue using args as-is.
+	//
+	// TODO: Attempt to read configuration file from default locations (cwd, .config, etc.)
+	let config_file = args.get_config_file();
+	if let Some(config_file) = config_file {
+		if let Ok(contents) = std::fs::read_to_string(config_file) {
+			let toml_args: Result<Args, toml::de::Error> = toml::from_str(&contents);
+			if let Ok(toml_args) = toml_args {
+				args.merge(toml_args);
+			}
+		}
+	}
+
+	let stats = args.uhyve.stats.unwrap_or_default();
+	let kernel_path = args.guest.kernel.clone();
+	let affinity = args.cpu.clone().get_affinity(&mut app);
 	let params = Params::from(args);
 
 	let vm = UhyveVm::new(kernel_path, params).unwrap_or_else(|e| panic!("Error: {e}"));
@@ -391,4 +505,197 @@ fn run_uhyve() -> i32 {
 
 fn main() {
 	process::exit(run_uhyve())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Tests whether the input '0-1,2' for Affinity works like in the CLI.
+	///
+	/// Implicitly, this tests the same program path as the one used in the CLI.
+	#[test]
+	fn test_toml_affinity_strings() {
+		let config: Args = toml::from_str(
+			r#"
+			[cpu]
+			cpu_count = 3
+			affinity = '0-1,2'
+		"#,
+		)
+		.unwrap();
+
+		assert_eq!(
+			config.cpu.clone().affinity.unwrap().0,
+			Affinity::from_str("0,1,2").unwrap().0
+		);
+
+		let mut app = Args::command();
+		// This should not panic, CPU number is equal.
+		let _affinity = config.cpu.get_affinity(&mut app);
+	}
+
+	/// Tests whether the input '[0,1,2]' (entering different usizes)
+	/// is parsed correctly. TOML-config file only.
+	#[test]
+	fn test_toml_affinity_usize_array() {
+		let config: Args = toml::from_str(
+			r#"
+			[cpu]
+			cpu_count = 3
+			affinity = [0, 1, 2]
+		"#,
+		)
+		.unwrap();
+
+		assert_eq!(
+			config.cpu.clone().affinity.unwrap().0,
+			Affinity::from_str("0,1,2").unwrap().0
+		);
+
+		let mut app = Args::command();
+		// This should not panic, CPU number is equal.
+		let _affinity = config.cpu.get_affinity(&mut app);
+	}
+
+	/// Tests whether an error appears if the defined affinity does
+	/// not match that of the assigned CPU cores.
+	#[test]
+	#[should_panic]
+	fn test_affinity_errors_when_lacking_cpu_cores() {
+		let config: Args = toml::from_str(
+			r#"
+			[cpu]
+			cpu_count = 1
+			affinity = [0, 1, 2]
+		"#,
+		)
+		.unwrap();
+
+		let mut app = Args::command();
+		let _affinity: Option<Vec<CoreId>> = config.cpu.get_affinity(&mut app);
+	}
+
+	/// Tests whether the fields that are not supposed to belong to
+	/// the Uhyve-wide configuration are actually skipped.
+	///
+	/// Note: Althuogh env_vars and kernel_args can be understood as
+	/// "specific to images", it is assumed that we will be able to
+	/// just append Uhyve-wide and image-specific configurations.
+	#[test]
+	fn test_toml_are_fields_actually_skipped() {
+		let config: Args = toml::from_str(
+			r#"
+			[uhyve]
+			file_mapping = ['foo:bar']
+			config = "/ilikerecursion"
+
+			[guest]
+			kernel = './data/x86_64/hello_c'
+		"#,
+		)
+		.unwrap();
+
+		let file_mapping = config.uhyve.file_mapping;
+		let config_file = config.uhyve.config;
+		let kernel = config.guest.kernel;
+
+		assert!(file_mapping.is_empty());
+		assert!(config_file.is_none());
+		assert!(kernel.to_str().unwrap().is_empty())
+	}
+
+	/// Tests whether TOML merge works as expected.
+	#[test]
+	fn test_toml_merge() {
+		// This is a bit of a workaround and doesn't test the cases that we
+		// deliberately ignore. However, this is covered by other tests.
+		//
+		// Everything with #[merge(skip)] is omitted in the meantime and not
+		// tested explicitly due to triviality.
+		let mut supposed_uhyve_cli_args: Args = toml::from_str(
+			r#"
+			[uhyve]
+			output = "test.txt"
+			stats = true
+			tempdir = "/here"
+			file_isolation = "strict"
+			gdb_port = 1
+
+			[memory]
+			memory_size = '4M'
+			no_aslr = true
+			thp = true
+			ksm = true
+
+			[cpu]
+			cpu_count = 4
+			affinity = [1, 2, 3, 4]
+			pit = true
+
+			[guest]
+			env_vars = ['foo=bar']
+		"#,
+		)
+		.unwrap();
+
+		let config_file: Args = toml::from_str(
+			r#"
+			[uhyve]
+			stats = false
+
+			[memory]
+			no_aslr = false
+			thp = false
+			ksm = false
+
+			[cpu]
+			pit = false
+
+			[guest]
+			env_vars = ['bar=foo']
+		"#,
+		)
+		.unwrap();
+
+		supposed_uhyve_cli_args.merge(config_file);
+
+		// Uhyve parameters
+		assert_eq!(
+			supposed_uhyve_cli_args.uhyve.output,
+			Some("test.txt".into())
+		);
+		assert!(supposed_uhyve_cli_args.uhyve.stats.unwrap());
+		assert_eq!(supposed_uhyve_cli_args.uhyve.tempdir.unwrap(), "/here");
+		#[cfg(target_os = "linux")]
+		assert_eq!(
+			supposed_uhyve_cli_args.uhyve.file_isolation,
+			Some("strict".into())
+		);
+		#[cfg(target_os = "linux")]
+		assert_eq!(supposed_uhyve_cli_args.uhyve.gdb_port.unwrap(), 1);
+
+		// Memory parameters
+		assert_eq!(
+			supposed_uhyve_cli_args.memory.memory_size.unwrap().get(),
+			4000000
+		);
+		assert!(supposed_uhyve_cli_args.memory.no_aslr.unwrap());
+		#[cfg(target_os = "linux")]
+		assert!(supposed_uhyve_cli_args.memory.thp.unwrap());
+		#[cfg(target_os = "linux")]
+		assert!(supposed_uhyve_cli_args.memory.ksm.unwrap());
+
+		// CPU parameters
+		assert_eq!(supposed_uhyve_cli_args.cpu.cpu_count.unwrap().get(), 4);
+		assert!(supposed_uhyve_cli_args.cpu.affinity.is_some());
+		#[cfg(target_os = "linux")]
+		assert!(supposed_uhyve_cli_args.cpu.pit.unwrap());
+
+		// Guest parameters
+		assert_eq!(
+			supposed_uhyve_cli_args.guest.env_vars,
+			vec!["foo=bar", "bar=foo"]
+		);
+	}
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -85,7 +85,7 @@ impl Default for Params {
 	}
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub struct CpuCount(NonZeroU32);
 
 impl CpuCount {
@@ -124,7 +124,7 @@ impl FromStr for CpuCount {
 	}
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub struct GuestMemorySize(Byte);
 
 impl GuestMemorySize {

--- a/src/params.rs
+++ b/src/params.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use byte_unit::{Byte, Unit};
+use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
@@ -84,7 +85,7 @@ impl Default for Params {
 	}
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub struct CpuCount(NonZeroU32);
 
 impl CpuCount {
@@ -123,7 +124,7 @@ impl FromStr for CpuCount {
 	}
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct GuestMemorySize(Byte);
 
 impl GuestMemorySize {


### PR DESCRIPTION
This adds support for machine image-independent configuration files for Uhyve. Certain machine-dependent parameters, such as file mapping, kernel arguments and kernel have been omitted for starters.

The Deserialization code for Affinity was a contribution by Ellen (@fogti) with minor adjustments.