### PR TITLE
ci(labeler): add automatic pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+'ci':
+  - changed-files:
+    - any-glob-to-any-file: ['.github/workflows/**']
+'tests':
+  - changed-files:
+    - any-glob-to-any-file: ['tests/**']
+'docs':
+  - changed-files:
+    - any-glob-to-all-files: ['*.md']
+'feature/security':
+  - changed-files:
+    - any-glob-to-any-file: ['src/isolation/**']
+'feature/uhyve-interface':
+  - changed-files:
+    - any-glob-to-any-file: ['uhyve-interface/**']

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,15 @@
+name: "Assign PR labels"
+on:
+  workflow_dispatch:
+  pull_request_target:
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true


### PR DESCRIPTION
Some new issue labels were added. This change attempts to partially automate the manual effort of labeling, which is otherwise helpful for being able to shift through past PRs concerning specific focus points.