### PR TITLE
fix(bin/uhyve): improve `Affinity` parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,6 @@ dependencies = [
  "clean-path",
  "core_affinity",
  "criterion",
- "either",
  "env_logger",
  "gdbstub",
  "gdbstub_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ byte-unit = { version = "5", features = ["byte", "serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 clean-path = "0.2.1"
 core_affinity = "0.8"
-either = "1.15"
 env_logger = "0.11"
 gdbstub = "0.7"
 gdbstub_arch = "0.3"


### PR DESCRIPTION
Fixes #1035
by decoupling Affinity::from_str from validation
  (instead, validation is moved into Affinity::validate)

Fixes #1036
by incorporating the refactored code written earlier.