### PR TITLE
feat(gdb): don't rely on resolving localhost, choose random port if no port is set

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -126,7 +126,9 @@ struct UhyveArgs {
 	/// GDB server port
 	///
 	/// Starts a GDB server on the provided port and waits for a connection.
-	#[clap(short = 's', long, env = "HERMIT_GDB_PORT")]
+	///
+	/// [default: 6677]
+	#[clap(short = 's', long, env = "HERMIT_GDB_PORT", num_args(0..=1), default_missing_value("6677"))]
 	#[serde(default)]
 	#[merge(strategy = merge::option::overwrite_none)]
 	#[cfg(target_os = "linux")]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -140,8 +140,6 @@ const LOCALHOST: [IpAddr; 2] = [
 ];
 
 fn wait_for_gdb_connection(port: u16) -> io::Result<TcpStream> {
-	eprintln!("Waiting for a local GDB connection on port {port}...");
-
 	let sock = TcpListener::bind(
 		[
 			SocketAddr::new(LOCALHOST[0], port),
@@ -149,6 +147,10 @@ fn wait_for_gdb_connection(port: u16) -> io::Result<TcpStream> {
 		]
 		.as_ref(),
 	)?;
+	eprintln!(
+		"Waiting for a local GDB connection on port {}...",
+		sock.local_addr().unwrap().port()
+	);
 	let (stream, addr) = sock.accept()?;
 
 	// Blocks until a GDB client connects via TCP.


### PR DESCRIPTION
GDB connections will be waited for in a v4 and a v6 localhost socket, while not using 'localhost' itself. Doing so causes issues e.g. in atomic Fedora distributions (inside of a containerized toolbox environment).

Further: The 'feature' of choosing a random port is actually a workaround to a bug: Before, the user would have been able to select 0 (as allowed by TcpListener::bind), and this would have been fine. However, Uhyve would report that it is awaiting a connection on port 0, when it is actually listening on another port. I found exposing TcpListener's functionality to the user cooler than trying to impose restrictions, but this will presumably not be of use to anyone, really.