### PR TITLE
nit(params): fix clippy::manual_is_multiple_of

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -193,7 +193,10 @@ impl TryFrom<Byte> for GuestMemorySize {
 	fn try_from(value: Byte) -> Result<Self, Self::Error> {
 		if value < Self::minimum() {
 			Err(InvalidGuestMemorySizeError::MemoryTooSmall(value))
-		} else if value.as_u64() % Byte::from_u64_with_unit(2, Unit::MiB).unwrap().as_u64() != 0 {
+		} else if !value
+			.as_u64()
+			.is_multiple_of(Byte::from_u64_with_unit(2, Unit::MiB).unwrap().as_u64())
+		{
 			Err(InvalidGuestMemorySizeError::NotAHugepage(value))
 		} else {
 			Ok(Self(value))


### PR DESCRIPTION
tested on `nightly-2025-08-07-x86_64-unknown-linux-gnu`

precise behavioral change not tested in great detail, but it doesn't seem like the affected LoC could fall e.g. under https://github.com/rust-lang/rust-clippy/issues/15335