### PR TITLE
fix(musl): add pthread workaround

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -34,6 +34,23 @@ static KVM: LazyLock<Kvm> = LazyLock::new(|| Kvm::new().unwrap());
 /// It is used to stop a vCPU from another thread.
 pub(crate) struct KickSignal;
 
+/// A way of sending pthread IDs reliably across threads.
+///
+/// # Platform-specific behavior
+///
+/// This is particularly necessary for musl, as `Pthread` is equal to `*mut c_void` there,
+/// which can't be passed to thread as easily
+///
+/// # Safety
+///
+/// This can be safely sent across threads because pthread IDs are just opaque identifiers
+/// and thread-safety is ensured by the pthread library.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PthreadWrapper(pub Pthread);
+
+unsafe impl Send for PthreadWrapper {}
+unsafe impl Sync for PthreadWrapper {}
+
 // TODO: nix::signal::Signal doesn't support real-time signals yet.
 // Start using the Signal type once this no longer is the case.
 //

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -394,7 +394,11 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 
 		trace!("Killing all threads");
 		for thread in &threads {
-			KickSignal::pthread_kill(thread.as_pthread_t()).unwrap();
+			// The following `as _` is necessary because on some platforms, the type (aliases)
+			// - std::os::unix::thread::RawPthread, and
+			// - libc::pthread_t
+			// can differ, and currently do so on x86_64-linux-musl.
+			KickSignal::pthread_kill(thread.as_pthread_t() as _).unwrap();
 		}
 
 		let cpu_results = threads


### PR DESCRIPTION
Discovered during an attempted experiment on an `aarch64-unknown-linux-musl` environment as I was experimenting with the memory implementation and an aarch64 port.