### PR TITLE
feat: add thinlto, abort panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ exclude = [
     "/tests"
 ]
 
+[profile.release]
+codegen-units = 1
+lto           = "thin"
+
 [lib]
 name = "uhyvelib"
 


### PR DESCRIPTION
Optimizations for reducing binary size by 25%. Thin LTO was chosen as a compromise so as to not negatively impact compilation times too much with limited knowledge of the actual benefit.

Fixes https://github.com/hermit-os/uhyve/issues/1040

---

P.S. The issue mentions measuring speedup, which I haven't done. So I limited the "intrusiveness" of the actual change and only applied it to the `release` profile.