### PR TITLE
fix(kvm): handle disabling exits gracefully

### DIFF
--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -144,8 +144,10 @@ impl VirtualizationBackendInternal for KvmVm {
 		let mut disable_exits = KVM
 			.check_extension_raw(KVM_CAP_X86_DISABLE_EXITS.into())
 			.cast_unsigned();
-		disable_exits &=
-			KVM_X86_DISABLE_EXITS_PAUSE | KVM_X86_DISABLE_EXITS_MWAIT | KVM_X86_DISABLE_EXITS_HLT;
+		disable_exits &= KVM_X86_DISABLE_EXITS_MWAIT
+			| KVM_X86_DISABLE_EXITS_HLT
+			| KVM_X86_DISABLE_EXITS_PAUSE
+			| KVM_X86_DISABLE_EXITS_CSTATE;
 		cap = kvm_bindings::kvm_enable_cap {
 			cap: KVM_CAP_X86_DISABLE_EXITS,
 			flags: 0,


### PR DESCRIPTION
This PR does three things with decreasing importance:

1. Don't panic anymore when failing to disable KVM exits.

   This may result in KVM exit variants being reported to Uhyve that have not been reported before and may not be handled properly. Still, we should rather panic at that point than panic this early.

   Now, three additional KVM exits may happen in cases where disabling them is not supported: MWAIT, HLT and PAUSE. All are related to suspending the CPU when idling and are potentially used by Hermit ([`interrupts.rs#L46-L87`](https://github.com/hermit-os/kernel/blob/96409344762c2c9b14c2592f71b205062c7ae246/src/arch/x86_64/kernel/interrupts.rs#L46-L87)).

   - MWAIT does not seem to be advertised by Uhyve via CPUID and is thus not used by Hermit. Perhaps it would be useful to add support for this in Uhyve, since it is currently Hermit's preferred way of suspending a CPU, but I have not questioned the status quo in that regard. As far as I know, MWAIT will still be handled by KVM, though, just not natively by the CPU anymore. Disabling and not disabling the MWAIT KVM exit had no noticeable impact for me. The CPU utilization was 100% in both cases.

   - HLT is used by Hermit if the `idle-poll` feature is disabled. Uhyve has ignored the HLT exit since 2020 (https://github.com/hermit-os/uhyve/pull/14) and is immediately jumping back into the vCPU, but I don't know if that is the correct way of handling it. [HLT](https://www.felixcloutier.com/x86/hlt) should ideally only continue execution on external events. For now, this has not been a problem, since HLT KVM exits were always disabled. That's the theory, at least. In practice, disabling the HLT KVM exit led to 100% CPU utilization, and not disabling it (but also not receiving it in Uhyve for some reason) dropped the CPU utilization to 0%.
     https://github.com/hermit-os/uhyve/blob/e7b9121607f08c446218eafade6606e1387dfc22/src/linux/x86_64/kvm_cpu.rs#L388-L391

   - PAUSE is used by Hermit if the `idle-poll` feature is enabled. As far as I know, PAUSE will still be handled by KVM, though, just not natively by the CPU anymore. Disabling and not disabling the PAUSE KVM exit had no noticeable impact for me. The CPU utilization was 100% in both cases.

2. Only disable valid KVM exits. That means that if only a subset of KVM exit disablements is supported, that subset will still be applied instead of just none.

3. Disable the C-state KVM exit too, completing the current set of disablable KVM exits. These are not used by Hermit, but I think this won't hurt. KVM_X86_DISABLE_EXITS_APERFMPERF (added in Linux 6.17) is not part of the kvm-bindings crate yet.

Also see the [KVM_CAP_X86_DISABLE_EXITS documentation](https://www.kernel.org/doc/html/v6.17/virt/kvm/api.html#kvm-cap-x86-disable-exits).

The original disable exits logic was in place since 2021 (https://github.com/hermit-os/uhyve/pull/59 and https://github.com/hermit-os/uhyve/commit/b14cce85bf622d46f2dd45aa20414f04a3053580). It was moved around a few times since then, but the logic never changed.

In the future, it might also make sense to make disabling KVM exits user-configurable. QEMU only disables KVM exits when the user specifies `-overcommit cpu-pm=on` (CPU power management). To quote the QEMU docs:

> Guest ability to manage power state of host cpus (increasing latency for other processes on the same host cpu, but decreasing latency for guest) can be enabled via ``cpu-pm=on`` (disabled by default). This works best when host CPU is not overcommitted. When used, host estimates of CPU cycle and power utilization will be incorrect, not taking into account guest idle time.

These KVM exits can be discussed a lot, and please open issues for open questions that you are interested in. I would strongly prefer more changes to happen after this PR is merged, since it reliably fixes the kernel CI, which will swiftly switch to a backported version of this PR (https://github.com/hermit-os/uhyve/commit/357a022f4f381b1ac80b064f88caae1a657b3687) until a new Uhyve release is ready.

Closes https://github.com/hermit-os/uhyve/issues/1129.