### PR TITLE
fix: don't delay vCPU threads

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -359,8 +359,6 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 
 					cpu.thread_local_init().expect("Unable to initialize vCPU");
 
-					thread::sleep(std::time::Duration::from_millis(cpu_id as u64 * 50));
-
 					struct UnparkOnDrop(Parker);
 
 					impl Drop for UnparkOnDrop {


### PR DESCRIPTION
Currently, we start each vCPU thread separated by a delay of 50 ms, which was introduced in https://github.com/hermit-os/uhyve/commit/99b42bd09a7249b0014b377023f5eb1d969dd668. I think this was done since previous kernel versions would use the stack immediately if the cores did not set up a global variable. This was changed at the same time as the delay was introduced in https://github.com/hermit-os/kernel/commit/136da1e135037f795aca1e6c54dd7792d718797a, though.

I think we no longer need to keep this around for backward compatibility and could benefit from faster SMP boots instead.

Furthermore, with this delay, a race condition can be triggered consistently: if we have a kernel that shuts down one core before all others have been started, for example, a non-SMP kernel on an SMP Uhyve. In that case, the main thread will try to kick vCPU threads out of KVM that are not even in KVM yet. Since the vCPU threads have a no-op signal handler, they will happily enter KVM after the delay, resulting in Uhyve hanging.

With the delay removed, I can no longer reproduce this race condition, though it is not strictly prevented.

We may want to merge this after https://github.com/hermit-os/uhyve/pull/1153 to have a more robust parking mechanism in place before merging this, but that is not strictly necessary, I think.