### PR TITLE
deps: `rand` shouldn't be optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,6 @@ path = "benches/benchmarks.rs"
 harness = false
 
 [features]
-default = ["aslr"]
-aslr = ["dep:rand"]
 instrument = ["rftrace", "rftrace-frontend"]
 
 [dependencies]
@@ -62,7 +60,7 @@ uhyve-interface = { version = "0.1.3", path = "uhyve-interface", features = ["st
 virtio-bindings = { version = "0.2", features = ["virtio-v4_14_0"] }
 rftrace = { version = "0.3", optional = true }
 rftrace-frontend = { version = "0.3", optional = true }
-rand = { version = "0.9", optional = true }
+rand = "0.9"
 shell-words = "1"
 sysinfo = { version = "0.37.2", default-features = false, features = ["system"] }
 vm-fdt = "0.3"
@@ -70,7 +68,7 @@ tempfile = "3.23"
 uuid = { version = "1.18.1", features = ["fast-rng", "v4"]}
 toml = "0.9.8"
 serde = { version = "1.0", features = ["derive"] }
-merge = { version = "0.2" }
+merge = "0.2"
 yoke = "0.8"
 nohash = "0.2"
 


### PR DESCRIPTION
reason:
```
error[E0432]: unresolved import `rand`
 --> src/arch/x86_64/mod.rs:6:5
  |
6 | use rand::Rng;
  |     ^^^^ help: a similar path exists: `vmm_sys_util::rand`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rand`
  --> src/arch/x86_64/mod.rs:20:16
   |
20 |     let mut rng = rand::rng();
   |                   ^^^^ use of unresolved module or unlinked crate `rand`
   |
   = help: if you wanted to use a crate named `rand`, use `cargo add rand` to add it to your `Cargo.toml`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `uhyve` (lib) due to 2 previous errors
```