### PR TITLE
fix(uhyve-interface): Fix-up macro for Rust Edition 2024

### DIFF
--- a/uhyve-interface/src/elf.rs
+++ b/uhyve-interface/src/elf.rs
@@ -8,7 +8,7 @@
 macro_rules! define_uhyve_interface_version {
 	() => {
 		#[used]
-		#[link_section = ".note.hermit.uhyve-interface-version"]
+		#[unsafe(link_section = ".note.hermit.uhyve-interface-version")]
 		static INTERFACE_VERSION: $crate::elf::Note = $crate::elf::Note::uhyveif_version();
 	};
 }


### PR DESCRIPTION
The latest edition switch to 2024 broke downstream consumers of uhyve-interface  because it also requires adjusting the ELF-.note-defining macros to prevent errors like the following:

```
error: unsafe attribute used without unsafe
  --> src/lib.rs:95:1
   |
95 | uhyve_interface::define_uhyve_interface_version!();
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ usage of unsafe attribute
   |
   = note: this error originates in the macro `uhyve_interface::define_uhyve_interface_version` (in Nightly builds, run with -Z macro-backtrace for more info)
help: wrap the attribute in `unsafe(...)`
  --> /home/fogti/.cargo/git/checkouts/uhyve-da4e7b3a9c9e3da7/d74257a/uhyve-interface/src/elf.rs:11:5
   |
11 |         #[unsafe(link_section = ".note.hermit.uhyve-interface-version")]
   |           +++++++                                                     +

error: could not compile `hermit-kernel` (lib) due to 1 previous error
```

This PR will become redundant when https://github.com/hermit-os/hermit-entry/pull/64 is merged and the kernel is updated to use `hermit_entry::define_uhyve_interface_version` instead.