### PR TITLE
refactor(uhyve-interface): move re-exported constants into `prelude` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
  "log",
  "plain",
  "time",
- "uhyve-interface 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uhyve-interface 0.1.3",
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ dependencies = [
  "time",
  "toml",
  "tun-tap",
- "uhyve-interface 0.1.3",
+ "uhyve-interface 0.2.0-alpha.0",
  "uuid",
  "virtio-bindings",
  "vm-fdt",
@@ -1755,10 +1755,10 @@ dependencies = [
 [[package]]
 name = "uhyve-interface"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390116b0481b52dbc7d979f858dcc426494714a3ba03e9534d26c8ea41b899e"
 dependencies = [
- "aarch64 0.0.14",
- "hermit-abi",
- "log",
+ "aarch64 0.0.13",
  "memory_addresses",
  "num_enum",
  "x86_64",
@@ -1766,11 +1766,11 @@ dependencies = [
 
 [[package]]
 name = "uhyve-interface"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7390116b0481b52dbc7d979f858dcc426494714a3ba03e9534d26c8ea41b899e"
+version = "0.2.0-alpha.0"
 dependencies = [
- "aarch64 0.0.13",
+ "aarch64 0.0.14",
+ "hermit-abi",
+ "log",
  "memory_addresses",
  "num_enum",
  "x86_64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ nix = { version = "0.30", features = ["mman", "pthread", "signal"] }
 thiserror = "2.0.17"
 time = "0.3"
 tun-tap = { version = "0.1.3", default-features = false }
-uhyve-interface = { version = "0.1.3", path = "uhyve-interface", features = ["std"] }
+uhyve-interface = { version = "0.2.0-alpha.0", path = "uhyve-interface", features = ["std"] }
 virtio-bindings = { version = "0.2", features = ["virtio-v4_14_0"] }
 rftrace = { version = "0.3", optional = true }
 rftrace-frontend = { version = "0.3", optional = true }

--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -5,7 +5,9 @@ use std::{
 	os::{fd::IntoRawFd, unix::ffi::OsStrExt},
 };
 
-use uhyve_interface::{GuestPhysAddr, Hypercall, HypercallAddress, MAX_ARGC_ENVC, parameters::*};
+use uhyve_interface::{
+	GuestPhysAddr, Hypercall, HypercallAddress, MAX_ARGC_ENVC, parameters::*, prelude::*,
+};
 
 use crate::{
 	isolation::{

--- a/tests/test-kernels/Cargo.lock
+++ b/tests/test-kernels/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "uhyve-interface"
-version = "0.1.3"
+version = "0.2.0-alpha.0"
 dependencies = [
  "aarch64",
  "hermit-abi",

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhyve-interface"
-version = "0.1.3"
+version = "0.2.0-alpha.0"
 edition = "2024"
 authors = [
   "Jonathan Klimt <jonathan.klimt@eonerc.rwth-aachen.de>",

--- a/uhyve-interface/src/lib.rs
+++ b/uhyve-interface/src/lib.rs
@@ -14,11 +14,13 @@ use num_enum::TryFromPrimitive;
 
 pub mod elf;
 pub mod parameters;
+pub mod prelude;
 
 pub use memory_addresses::{PhysAddr as GuestPhysAddr, VirtAddr as GuestVirtAddr};
 
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("Using uhyve-interface on a non-64-bit system is not (yet?) supported");
+
 use parameters::*;
 
 /// The version of the Uhyve interface. Note: This is not the same as the semver of the crate but

--- a/uhyve-interface/src/parameters.rs
+++ b/uhyve-interface/src/parameters.rs
@@ -144,13 +144,3 @@ pub struct SerialWriteBufferParams {
 	pub buf: GuestPhysAddr,
 	pub len: usize,
 }
-
-pub use hermit_abi::{
-	O_APPEND, O_CREAT, O_DIRECTORY, O_EXCL, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR,
-	SEEK_END, SEEK_SET,
-	errno::{EBADF, EFAULT, EINVAL, ENOENT, EROFS},
-};
-
-// File operations supported by Hermit and Uhyve
-pub const ALLOWED_OPEN_FLAGS: i32 =
-	O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_TRUNC | O_APPEND | O_DIRECTORY;

--- a/uhyve-interface/src/prelude.rs
+++ b/uhyve-interface/src/prelude.rs
@@ -1,0 +1,11 @@
+//! Generally useful stuff.
+
+pub use hermit_abi::{
+	O_APPEND, O_CREAT, O_DIRECTORY, O_EXCL, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR,
+	SEEK_END, SEEK_SET,
+	errno::{EBADF, EFAULT, EINVAL, ENOENT, EROFS},
+};
+
+// File operations supported by Hermit and Uhyve
+pub const ALLOWED_OPEN_FLAGS: i32 =
+	O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_TRUNC | O_APPEND | O_DIRECTORY;


### PR DESCRIPTION
This is marked as a draft because it should only be merged after #1164.