### PR TITLE
annotate(hypercall/lseek): make sure missing constants cause compile-time error

### DIFF
--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -302,6 +302,7 @@ pub fn lseek(syslseek: &mut LseekParams, file_map: &mut UhyveFileMap) {
 			libc::lseek(*r, syslseek.offset as i64, syslseek.whence) as isize
 		},
 		Some(FdData::Virtual { data, offset }) => {
+			#[forbid(unused_variables, unreachable_patterns)]
 			let tmp = match syslseek.whence {
 				SEEK_SET => 0,
 				SEEK_CUR => *offset as isize,


### PR DESCRIPTION
Related: https://github.com/hermit-os/uhyve/pull/1145#discussion_r2524433224

In the Uhyve V2 Interface PR, the problem popped up that missing re-exports of `SEEK_*` constants only show up as warnings, and this gets fixed by this PR.