### PR TITLE
feat(uhyvefilemap): add I/O mode settings

### DIFF
--- a/src/hypercall.rs
+++ b/src/hypercall.rs
@@ -136,6 +136,10 @@ pub fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut UhyveFile
 			// If a supposed attacker can predict where we open a file and its filename,
 			// this contigency, together with O_CREAT, will cause the write to fail.
 			flags |= O_EXCL;
+			#[cfg(target_os = "linux")]
+			{
+				flags |= file_map.get_io_mode_flags();
+			}
 
 			let host_path_c_string = file_map.create_temporary_file(guest_path);
 			let new_host_path = host_path_c_string.as_c_str().as_ptr();

--- a/src/params.rs
+++ b/src/params.rs
@@ -11,6 +11,9 @@ use byte_unit::{Byte, Unit};
 use serde::Deserialize;
 use thiserror::Error;
 
+#[cfg(target_os = "linux")]
+pub use crate::isolation::filemap::UhyveIoMode;
+
 #[derive(Debug, Clone)]
 pub struct Params {
 	/// Guest RAM size
@@ -47,6 +50,10 @@ pub struct Params {
 	#[cfg(target_os = "linux")]
 	pub file_isolation: FileSandboxMode,
 
+	/// I/O mode for processing files files on the host
+	#[cfg(target_os = "linux")]
+	pub io_mode: UhyveIoMode,
+
 	/// Kernel output handling
 	pub output: Output,
 
@@ -76,6 +83,8 @@ impl Default for Params {
 			tempdir: Default::default(),
 			#[cfg(target_os = "linux")]
 			file_isolation: FileSandboxMode::default(),
+			#[cfg(target_os = "linux")]
+			io_mode: Default::default(),
 			kernel_args: Default::default(),
 			output: Default::default(),
 			stats: false,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -207,6 +207,8 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 		let file_mapping = Mutex::new(UhyveFileMap::new(
 			&params.file_mapping,
 			params.tempdir.clone(),
+			#[cfg(target_os = "linux")]
+			params.io_mode,
 		));
 		let mut mounts: Vec<_> = file_mapping
 			.lock()


### PR DESCRIPTION
Being able to override the flags of the open call can be useful for
benchmarking. Two settings are offered for --io-mode: host-direct
and host-directsync, which append O_DIRECT and O_DIRECT | O_SYNC
respectively. This leaves room for future, potentially more complex
options.