### PR TITLE
feat: make `KVM_CAP_X86_DISABLE_EXITS` opt-in

### DIFF
--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -141,21 +141,23 @@ impl VirtualizationBackendInternal for KvmVm {
 		vm.enable_cap(&cap)
 			.expect_err("The support of KVM_CAP_IRQFD is currently required");
 
-		let mut disable_exits = KVM
-			.check_extension_raw(KVM_CAP_X86_DISABLE_EXITS.into())
-			.cast_unsigned();
-		disable_exits &= KVM_X86_DISABLE_EXITS_MWAIT
-			| KVM_X86_DISABLE_EXITS_HLT
-			| KVM_X86_DISABLE_EXITS_PAUSE
-			| KVM_X86_DISABLE_EXITS_CSTATE;
-		cap = kvm_bindings::kvm_enable_cap {
-			cap: KVM_CAP_X86_DISABLE_EXITS,
-			flags: 0,
-			..Default::default()
-		};
-		cap.args[0] = disable_exits.into();
-		if let Err(err) = vm.enable_cap(&cap) {
-			error!("kvm: cannot disable KVM exits: {err}");
+		if params.cpu_pm {
+			let mut disable_exits = KVM
+				.check_extension_raw(KVM_CAP_X86_DISABLE_EXITS.into())
+				.cast_unsigned();
+			disable_exits &= KVM_X86_DISABLE_EXITS_MWAIT
+				| KVM_X86_DISABLE_EXITS_HLT
+				| KVM_X86_DISABLE_EXITS_PAUSE
+				| KVM_X86_DISABLE_EXITS_CSTATE;
+			cap = kvm_bindings::kvm_enable_cap {
+				cap: KVM_CAP_X86_DISABLE_EXITS,
+				flags: 0,
+				..Default::default()
+			};
+			cap.args[0] = disable_exits.into();
+			if let Err(err) = vm.enable_cap(&cap) {
+				error!("kvm: cannot disable KVM exits: {err}");
+			}
 		}
 
 		let evtfd = EventFd::new(0).unwrap();

--- a/src/params.rs
+++ b/src/params.rs
@@ -27,6 +27,14 @@ pub struct Params {
 	/// Number of guest CPUs
 	pub cpu_count: CpuCount,
 
+	/// Allows the guest to manage host CPU power state.
+	///
+	/// This decreases the latency for the guest, but increases latency for other processes on the same host CPU.
+	/// This works best when the host CPUs are not overcommitted.
+	/// The host estimates incorrect CPU usage, due to not knowing about guest idle time.
+	#[cfg(target_os = "linux")]
+	pub cpu_pm: bool,
+
 	/// Create a PIT
 	#[cfg(target_os = "linux")]
 	pub pit: bool,
@@ -71,6 +79,8 @@ impl Default for Params {
 			#[cfg(target_os = "linux")]
 			pit: false,
 			cpu_count: Default::default(),
+			#[cfg(target_os = "linux")]
+			cpu_pm: false,
 			gdb_port: Default::default(),
 			file_mapping: Default::default(),
 			tempdir: Default::default(),


### PR DESCRIPTION
This PR finally fixes https://github.com/hermit-os/uhyve/issues/1150.

We only get the error on GitHub runners with an Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. It works just fine on GitHub runners with an AMD EPYC 7763 64-Core Processor.

On the Intel runners, setting `KVM_X86_DISABLE_EXITS_HLT` succeeds but results in the KVM entry failure later. This makes sense, since allowing the guest to manage the host CPU power state is bad in a nestedly virtualized CI environment. The issue can also be reproduced with QEMU with `-overcommit cpu-pm=on`:

```
KVM: entry failed, hardware error 0x0
EAX=00000000 EBX=00000000 ECX=00000000 EDX=000606a6
ESI=00000000 EDI=00000000 EBP=00000000 ESP=00000000
EIP=0000fff0 EFL=00000002 [-------] CPL=0 II=0 A20=1 SMM=0 HLT=0
ES =0000 00000000 0000ffff 00009300
CS =f000 ffff0000 0000ffff 00009b00
SS =0000 00000000 0000ffff 00009300
DS =0000 00000000 0000ffff 00009300
FS =0000 00000000 0000ffff 00009300
GS =0000 00000000 0000ffff 00009300
LDT=0000 00000000 0000ffff 00008200
TR =0000 00000000 0000ffff 00008b00
GDT=     00000000 0000ffff
IDT=     00000000 0000ffff
CR0=60000010 CR2=00000000 CR3=00000000 CR4=00000000
DR0=0000000000000000 DR1=0000000000000000 DR2=0000000000000000 DR3=0000000000000000 
DR6=00000000ffff0ff0 DR7=0000000000000400
EFER=0000000000000000
Code=04 66 41 eb f1 66 83 c9 ff 66 89 c8 66 5b 66 5e 66 5f 66 c3 <ea> 5b e0 00 f0 30 36 2f 32 33 2f 39 39 00 fc 00 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ??
```

Apart from QEMU, I have only found one VMM on GitHub that uses `KVM_CAP_X86_DISABLE_EXITS` at all, and that project does not have a CI: [Quark/qvisor/src/runc/runtime/vm_type/noncc.rs#L323-L330](https://github.com/QuarkContainer/Quark/blob/afe1a23cc82651cac1cb549465eb53d736c5b38b/qvisor/src/runc/runtime/vm_type/noncc.rs#L323-L330)

This PR adds a non-default `cpu-pm` CLI flag, similar to QEMU.
