### PR TITLE
feat(gdb): add gdbstub feature to allow disabling it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ path = "benches/benchmarks.rs"
 harness = false
 
 [features]
+# enables gdbstub support (linux x86_64). disabling it is intended as a convenience feature for devs
+# (i.e. refactors, bring-ups). disabling this won't remove all gdbstub references from binary.
+gdbstub = ["dep:gdbstub_arch"]
 instrument = ["dep:rftrace", "dep:rftrace-frontend"]
 
 [dependencies]
@@ -42,7 +45,7 @@ clean-path = "0.2.1"
 core_affinity = "0.8"
 env_logger = "0.11"
 gdbstub = "0.7"
-gdbstub_arch = "0.3"
+gdbstub_arch = { version = "0.3", optional = true }
 hermit-entry = { version = "0.10.7", features = ["loader"] }
 libc = "0.2"
 log = "0.4"

--- a/src/arch/x86_64/registers/mod.rs
+++ b/src/arch/x86_64/registers/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "gdbstub"))]
 pub mod debug;

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -374,6 +374,7 @@ impl KvmCpu {
 		println!("{name}       {seg:?}");
 	}
 
+	#[cfg(feature = "gdbstub")]
 	pub(crate) fn get_vcpu(&self) -> &VcpuFd {
 		&self.vcpu
 	}

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -6,8 +6,14 @@ use crate::{HypervisorResult, os::DebugExitInfo};
 
 /// Reasons for vCPU exits.
 #[cfg_attr(
-	target_os = "macos",
-	expect(dead_code, reason = "Not all variants used in macOS.")
+	any(
+		target_os = "macos",
+		all(target_os = "linux", not(feature = "gdbstub"))
+	),
+	expect(
+		dead_code,
+		reason = "Some variants are only used when gdb support is included."
+	)
 )]
 pub enum VcpuStopReason {
 	/// The vCPU stopped for debugging.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -122,7 +122,13 @@ pub(crate) struct KernelInfo {
 	/// The first instruction after boot
 	pub entry_point: GuestPhysAddr,
 	/// The starting position of the image in physical memory
-	#[cfg_attr(target_os = "macos", expect(dead_code))] // currently only needed in gdb
+	#[cfg_attr(
+		any(
+			target_os = "macos",
+			all(target_os = "linux", not(feature = "gdbstub"))
+		),
+		expect(dead_code, reason = "Currently only needed in gdb.")
+	)]
 	pub kernel_address: GuestPhysAddr,
 	pub params: Params,
 	pub path: PathBuf,


### PR DESCRIPTION
gdbstub can be highly annoying in the following situations:
- refactoring anything vCPU-related
- bringups to new architectures

the decision is to make it 'optional'; not in the sense of completely removing all traces of it (because the maintenance overhead is too high) but in the sense that it removes enough so that the hurdles in the two situations above are (hopefully) mostly dealt with. this helps developers have cleaner local git histories and not comment portions of the source code in and out. :)