### PR TITLE
build: gate optional deps behind instrument feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ path = "benches/benchmarks.rs"
 harness = false
 
 [features]
-instrument = ["rftrace", "rftrace-frontend"]
+instrument = ["dep:rftrace", "dep:rftrace-frontend"]
 
 [dependencies]
 align-address = "0.3.0"


### PR DESCRIPTION
Currently, it is possible to enable rftrace and/or rftrace-instrument without enabling the instrument feature. We should not expose features bearing the same name as these two optional dependencies.