### PR TITLE
build(deps): upgrade align-address to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2df0852593ebb4ed15e4fce123daf16a272b8d4449ae75050d6b9d7cea461a21"
 dependencies = [
  "aarch64-cpu",
- "memory_addresses",
+ "memory_addresses 0.2.4",
  "tock-registers",
 ]
 
@@ -859,6 +859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda000d3ae14c3036d35e0251ece9684731c5123c5149e7bd34b978c25b11e3"
 dependencies = [
  "align-address 0.3.0",
+ "cfg-if",
+]
+
+[[package]]
+name = "memory_addresses"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d19077c1bd58a846e275c3bb80527600ab8afbfb2768a80eb39f77cf93f1d"
+dependencies = [
+ "align-address 0.4.0",
  "cfg-if",
  "x86",
  "x86_64",
@@ -1767,7 +1777,7 @@ dependencies = [
 name = "uhyve"
 version = "0.7.0"
 dependencies = [
- "align-address 0.3.0",
+ "align-address 0.4.0",
  "bitflags 2.10.0",
  "byte-unit",
  "clap",
@@ -1785,7 +1795,7 @@ dependencies = [
  "libc",
  "log",
  "mac_address",
- "memory_addresses",
+ "memory_addresses 0.3.0",
  "merge",
  "nix 0.31.1",
  "nohash",
@@ -1820,7 +1830,7 @@ dependencies = [
  "aarch64",
  "hermit-abi",
  "log",
- "memory_addresses",
+ "memory_addresses 0.3.0",
  "num_enum",
  "x86_64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ harness = false
 instrument = ["dep:rftrace", "dep:rftrace-frontend"]
 
 [dependencies]
-align-address = "0.3.0"
+align-address = "0.4"
 byte-unit = { version = "5", features = ["byte", "serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 clean-path = "0.2.1"
@@ -80,14 +80,14 @@ xhypervisor = { version = "0.3.0", features = ["macos_15_0_0"] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.15", default-features = false }
 raw-cpuid = "11"
-memory_addresses = { version = "0.2.4", default-features = false, features = [
+memory_addresses = { version = "0.3", default-features = false, features = [
   "conversions",
   "x86_64",
 ] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 bitflags = "2.10"
-memory_addresses = { version = "0.2.4", default-features = false, features = [
+memory_addresses = { version = "0.3", default-features = false, features = [
   "aarch64",
 ] }
 

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["os"]
 
 [dependencies]
 log = { version = "0.4", optional = true }
-memory_addresses = "0.2.4"
+memory_addresses = "0.3"
 num_enum = { version = "0.7", default-features = false }
 hermit-abi = "0.5"
 


### PR DESCRIPTION
This also upgrades `memory_addresses` to 0.3.

Note that this is a breaking change for uhyve-interface.

See https://github.com/hermit-os/uhyve/pull/1231.