### PR TITLE
ci(labeler): remove label sync

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -11,5 +11,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v6
-      with:
-        sync-labels: true


### PR DESCRIPTION
Although this helped once when a uhyve-interface change was added after it was pushed, it is bothersome when one sets a label and it is removed because it's not part of the pre-defined files (e.g. after a force-push).