### PR TITLE
feat(isolation,vm): Implement support for Hermit images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,9 +693,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hermit-entry"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b12e2085187f60d10d5842792075a7cf2e5c49ce8a368a1fc3a6c4188de8979"
+checksum = "2ed687eb25e93c537518279fbd181547d1916e920aaaa70daf8a275dd1e1389d"
 dependencies = [
  "align-address 0.4.0",
  "byte-unit",
@@ -681,7 +706,7 @@ dependencies = [
  "serde",
  "tar-no-std",
  "time",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -901,6 +926,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1563,6 +1598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,19 +1753,6 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml"
 version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
@@ -1743,15 +1771,6 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "toml_datetime"
@@ -1809,6 +1828,7 @@ dependencies = [
  "core_affinity",
  "criterion",
  "env_logger",
+ "flate2",
  "gdbstub",
  "gdbstub_arch",
  "hermit-abi",
@@ -1832,10 +1852,11 @@ dependencies = [
  "serde",
  "shell-words",
  "sysinfo",
+ "tar-no-std",
  "tempfile",
  "thiserror",
  "time",
- "toml 1.0.3+spec-1.1.0",
+ "toml",
  "tun-tap",
  "uhyve-interface",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clean-path = "0.2.1"
 core_affinity = "0.8"
 env_logger = "0.11"
+flate2 = "1.1"
 gdbstub = "0.7"
 gdbstub_arch = "0.3"
 hermit-abi = "0.5"
@@ -67,6 +68,7 @@ virtio-bindings = "~0.2.7"
 vm-fdt = "0.3"
 vm-memory = { version = "0.18", features = ["backend-mmap"] }
 uuid = { version = "1.21.0", features = ["fast-rng", "v4"]}
+tar-no-std = { version = "0.4", features = ["alloc"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = "0.14"

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -400,7 +400,7 @@ impl<'de> serde::de::Deserialize<'de> for Affinity {
 #[derive(Debug, Default, Deserialize, Merge, Parser)]
 #[cfg_attr(test, derive(PartialEq))]
 struct GuestArgs {
-	/// The kernel to execute
+	/// The kernel or Hermit image to execute
 	#[serde(skip)]
 	#[merge(skip)]
 	kernel: PathBuf,

--- a/src/isolation/filemap/tree.rs
+++ b/src/isolation/filemap/tree.rs
@@ -16,7 +16,6 @@ pub enum Leaf {
 	OnHost(PathBuf),
 
 	/// An in-memory file
-	#[allow(dead_code)]
 	Virtual(Arc<[u8]>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,24 @@ pub enum HypervisorError {
 	#[error("Invalid kernel path ({0})")]
 	InvalidKernelPath(PathBuf),
 
+	#[error(transparent)]
+	HermitImageError(#[from] crate::isolation::filemap::HermitImageError),
+
+	#[error("Unable to find Hermit image config in archive")]
+	HermitImageConfigNotFound,
+
+	#[error("Unable to parse Hermit image config: {0}")]
+	HermitImageConfigParseError(#[from] toml::de::Error),
+
+	#[error("Insufficient guest memory size: got = {got}, wanted = {wanted}")]
+	InsufficientGuestMemorySize {
+		got: byte_unit::Byte,
+		wanted: byte_unit::Byte,
+	},
+
+	#[error("Insufficient guest CPU count: got = {got}, wanted = {wanted}")]
+	InsufficientGuestCPUs { got: u32, wanted: u32 },
+
 	#[error("Kernel Loading Error: {0}")]
 	LoadedKernelError(#[from] vm::LoadKernelError),
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -150,7 +150,7 @@ impl FromStr for CpuCount {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
-pub struct GuestMemorySize(Byte);
+pub struct GuestMemorySize(pub(crate) Byte);
 
 impl GuestMemorySize {
 	const fn minimum() -> Byte {
@@ -257,13 +257,13 @@ impl Default for EnvVars {
 		Self::Set(HashMap::new())
 	}
 }
-impl<S: AsRef<str> + std::fmt::Debug + PartialEq<S> + From<&'static str>> TryFrom<&[S]>
+impl<S: AsRef<str> + core::fmt::Debug + PartialEq + PartialEq<&'static str>> TryFrom<&[S]>
 	for EnvVars
 {
 	type Error = &'static str;
 
 	fn try_from(v: &[S]) -> Result<Self, Self::Error> {
-		if v.contains(&S::from("host")) {
+		if v.iter().any(|i| *i == "host") {
 			if v.len() != 1 {
 				warn!(
 					"Specifying -e host discards all other explicitly specified environment vars"

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,5 +1,6 @@
 use std::{
 	env, fmt, fs, io,
+	mem::{drop, take},
 	num::NonZero,
 	os::unix::prelude::JoinHandleExt,
 	path::PathBuf,
@@ -10,8 +11,9 @@ use std::{
 
 use core_affinity::CoreId;
 use hermit_entry::{
-	HermitVersion, UhyveIfVersion,
+	Format, HermitVersion, UhyveIfVersion,
 	boot_info::{BootInfo, HardwareInfo, LoadInfo, PlatformInfo, RawBootInfo, SerialPortBase},
+	config, detect_format,
 	elf::{KernelObject, LoadedKernel, ParseKernelError},
 };
 use internal::VirtualizationBackendInternal;
@@ -24,7 +26,7 @@ use crate::{
 	consts::*,
 	fdt::Fdt,
 	generate_address,
-	isolation::filemap::UhyveFileMap,
+	isolation::filemap::{UhyveFileMap, UhyveMapLeaf},
 	mem::MmapMemory,
 	os::KickSignal,
 	params::{EnvVars, Params},
@@ -137,11 +139,125 @@ pub struct UhyveVm<VirtBackend: VirtualizationBackend> {
 	pub(crate) kernel_info: Arc<KernelInfo>,
 }
 impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
-	pub fn new(kernel_path: PathBuf, params: Params) -> HypervisorResult<UhyveVm<VirtBackend>> {
+	pub fn new(kernel_path: PathBuf, mut params: Params) -> HypervisorResult<UhyveVm<VirtBackend>> {
 		let memory_size = params.memory_size.get();
 
-		let elf = fs::read(&kernel_path)
+		let kernel_data = fs::read(&kernel_path)
 			.map_err(|_e| HypervisorError::InvalidKernelPath(kernel_path.clone()))?;
+
+		// TODO: file_mapping not in kernel_info
+		let mut file_mapping = UhyveFileMap::new(
+			&params.file_mapping,
+			params.tempdir.clone(),
+			#[cfg(target_os = "linux")]
+			params.io_mode,
+		);
+
+		// `kernel_data` might be an Hermit image
+		let elf = match detect_format(&kernel_data[..]) {
+			None => return Err(HypervisorError::InvalidKernelPath(kernel_path.clone())),
+			Some(Format::Elf) => kernel_data,
+			Some(Format::Gzip) => {
+				{
+					use io::Read;
+
+					// decompress image
+					let mut buf_decompressed = Vec::new();
+					flate2::bufread::GzDecoder::new(&kernel_data[..])
+						.read_to_end(&mut buf_decompressed)?;
+					drop(kernel_data);
+
+					// insert Hermit image tree into file map
+					file_mapping.add_hermit_image(&buf_decompressed[..])?;
+				}
+
+				let config_data = if let Some(UhyveMapLeaf::Virtual(data)) =
+					file_mapping.get_host_path(&("/".to_string() + config::Config::DEFAULT_PATH))
+				{
+					data
+				} else {
+					return Err(HypervisorError::HermitImageConfigNotFound);
+				};
+
+				let config: config::Config<'_> = toml::from_slice(&config_data[..])?;
+
+				// handle Hermit image configuration
+				match config {
+					config::Config::V1 {
+						mut input,
+						requirements,
+						kernel,
+					} => {
+						// .input
+						if params.kernel_args.is_empty() {
+							params.kernel_args.append(
+								&mut take(&mut input.kernel_args)
+									.into_iter()
+									.map(|i| i.into_owned())
+									.collect(),
+							);
+							if !input.app_args.is_empty() {
+								params.kernel_args.push("--".to_string());
+								params.kernel_args.append(
+									&mut take(&mut input.app_args)
+										.into_iter()
+										.map(|i| i.into_owned())
+										.collect(),
+								)
+							}
+						}
+						debug!("Passing kernel arguments: {:?}", &params.kernel_args);
+
+						// don't pass privileged env-var commands through
+						input.env_vars.retain(|i| i.contains('='));
+
+						if let EnvVars::Set(env) = &mut params.env {
+							if let Ok(EnvVars::Set(prev_env_vars)) =
+								EnvVars::try_from(&input.env_vars[..])
+							{
+								// env vars from params take precedence
+								let new_env_vars = take(env);
+								*env = prev_env_vars.into_iter().chain(new_env_vars).collect();
+							} else {
+								warn!("Unable to parse env vars from Hermit image configuration");
+							}
+						} else if input.env_vars.is_empty() {
+							info!("Ignoring Hermit image env vars due to `-e host`");
+						}
+
+						// .requirements
+
+						// TODO: what about default memory size?
+						if let Some(required_memory_size) = requirements.memory
+							&& params.memory_size.0 < required_memory_size
+						{
+							return Err(HypervisorError::InsufficientGuestMemorySize {
+								got: params.memory_size.0,
+								wanted: required_memory_size,
+							});
+						}
+
+						if params.cpu_count.get() < requirements.cpus {
+							return Err(HypervisorError::InsufficientGuestCPUs {
+								got: params.cpu_count.get(),
+								wanted: requirements.cpus,
+							});
+						}
+
+						// .kernel
+						if let Some(UhyveMapLeaf::Virtual(data)) =
+							file_mapping.get_host_path(&kernel)
+						{
+							data.to_vec()
+						} else {
+							error!("Unable to find kernel in Hermit image");
+							return Err(HypervisorError::InvalidKernelPath(kernel_path.clone()));
+						}
+					}
+				}
+			}
+		};
+
 		let object: KernelObject<'_> =
 			KernelObject::parse(&elf).map_err(LoadKernelError::ParseKernelError)?;
 
@@ -203,13 +319,6 @@ impl<VirtBackend: VirtualizationBackend> UhyveVm<VirtBackend> {
 		#[cfg(not(target_os = "linux"))]
 		let mut mem = MmapMemory::new(memory_size, guest_address, false, false);
 
-		// TODO: file_mapping not in kernel_info
-		let file_mapping = UhyveFileMap::new(
-			&params.file_mapping,
-			params.tempdir.clone(),
-			#[cfg(target_os = "linux")]
-			params.io_mode,
-		);
 		let mounts: Vec<_> = file_mapping.get_all_guest_dirs().collect();
 
 		let serial = UhyveSerial::from_params(&params.output)?;


### PR DESCRIPTION
This is the Hermit image implementation variant which uses virtual (in-memory) files on the hypervisor level (in contrast to the kernel level).

Depends on #1256.