### PR TITLE
Codecov warning

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
 coverage:
   status:
     patch: off
-    project: 
+    project:
       default:
         target: auto   # Require same coverage ratio as base (from PR base or parent commit)
-        # Allow a drop of 1%, to account for  fluctuations with regards to certain 
+        # Allow a drop of 2%, to account for  fluctuations with regards to certain
         # lines sometimes being present and missing, and sometimes not compiled at all
-        threshold: 1% 
+        threshold: 2%


### PR DESCRIPTION
Experimental. I think I've observed Codecov failures due to sunken coverage. As we don't have strict coverage rules, this should not block CIs.
