### PR TITLE
virtio/net: fix read_net_status panic on sub-word reads

### DIFF
--- a/src/virtio/net.rs
+++ b/src/virtio/net.rs
@@ -406,7 +406,9 @@ impl VirtioNetPciDevice {
 	}
 
 	pub fn read_net_status(&self, data: &mut [u8]) {
-		data.copy_from_slice(&self.header_caps.dev.status.bits().to_le_bytes())
+		let bytes = self.header_caps.dev.status.bits().to_le_bytes();
+		let len = data.len().min(bytes.len());
+		data[..len].copy_from_slice(&bytes[..len]);
 	}
 
 	pub fn read_mtu(&self, data: &mut [u8]) {


### PR DESCRIPTION
## Problem

`read_net_status` uses `copy_from_slice` which **panics** when the destination slice length does not exactly match the source length:

```rust
pub fn read_net_status(&self, data: &mut [u8]) {
    data.copy_from_slice(&self.header_caps.dev.status.bits().to_le_bytes())
}
```

The virtio device config space can be accessed in 1-byte or 2-byte chunks (not only 4 bytes). When the guest reads `NET_STATUS` with a 1- or 2-byte access, the caller passes a shorter slice and the function panics with:

```
called `Result::unwrap()` on an `Err` value: "destination and source slices have different lengths"
```

This was reproduced with hermit 0.13.0 booting on uhyve with virtio-net: uhyve panicked during network initialisation before the guest application started.

## Fix

Copy only `min(dst.len(), src.len())` bytes so that sub-word reads succeed instead of panicking.

## Testing

Verified with hermit 0.13.0 + a Rust HTTP client (`x86_64-unknown-hermit`). Before fix: uhyve panics at boot. After fix: virtio-net initialises and TCP connections work normally.