### PR TITLE
Uhyve interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "uhyve-interface"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aarch64",
  "hermit-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ tempfile = "3.27"
 thiserror = "2.0.18"
 time = "0.3"
 toml = "1"
-uhyve-interface = { version = "0.2.0", path = "uhyve-interface", features = ["std"] }
+uhyve-interface = { version = "0.3.0", path = "uhyve-interface", features = ["std"] }
 virtio-bindings = "~0.2.7"
 vm-fdt = "0.3"
 vm-memory = { version = "0.18", features = ["backend-mmap"] }

--- a/tests/test-kernels/Cargo.lock
+++ b/tests/test-kernels/Cargo.lock
@@ -188,7 +188,7 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "uhyve-interface"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aarch64",
  "hermit-abi",

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhyve-interface"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["The Hermit Project Developers"]
 description = "The interface between uhyve and a guest VM"

--- a/uhyve-interface/src/lib.rs
+++ b/uhyve-interface/src/lib.rs
@@ -60,4 +60,4 @@ compile_error!("Using uhyve-interface on a non-64-bit system is not (yet?) suppo
 
 /// The version of the Uhyve interface. Note: This is not the same as the semver of the crate but
 /// should be increased on every version bump that changes the API.
-pub const UHYVE_INTERFACE_VERSION: u32 = 2;
+pub const UHYVE_INTERFACE_VERSION: u32 = 3;

--- a/uhyve-interface/src/v2/mod.rs
+++ b/uhyve-interface/src/v2/mod.rs
@@ -30,6 +30,7 @@ pub enum HypercallAddress {
 	Getdents = 0x1160,
 	FileStat = 0x1170,
 	FileFstat = 0x1180,
+	Mkdir = 0x1190,
 	SharedMemOpen = 0x1200,
 	SharedMemClose = 0x1210,
 }
@@ -45,6 +46,7 @@ into_hypercall_addresses! {
 			FileUnlink,
 			FileWrite,
 			Getdents,
+			Mkdir,
 			FileStat,
 			FileFstat,
 			SerialReadBuffer,
@@ -73,6 +75,8 @@ pub enum Hypercall<'a> {
 	FileStat(&'a mut StatParams),
 	/// Read file metadata for an open descriptor. Similar to `fstat(2)`.
 	FileFstat(&'a mut FstatParams),
+	/// Create a new directory.
+	Mkdir(&'a mut MkdirParams),
 	/// Write a char to the terminal.
 	SerialWriteByte(u8),
 	/// Write a buffer to the terminal

--- a/uhyve-interface/src/v2/parameters.rs
+++ b/uhyve-interface/src/v2/parameters.rs
@@ -126,6 +126,30 @@ pub struct GetdentParams {
 	pub ret: GetdentResult,
 }
 
+/// Result of a [`Mkdir`](crate::v2::Hypercall::Mkdir) hypercall.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub enum MkdirResult {
+	/// No result. Guests should set this value before calling the hypercall.
+	None,
+	/// Directory was created.
+	Success,
+	/// Error with libc errno.
+	Error(i32),
+}
+
+/// Parameters for a [`Mkdir`](crate::v2::Hypercall::Mkdir) hypercall.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct MkdirParams {
+	/// Path to create. Zero terminated C-String.
+	pub path: GuestPhysAddr,
+	/// Length of the path buffer.
+	pub len: u64,
+	/// Return value of the hypercall.
+	pub ret: MkdirResult,
+}
+
 /// Which stat-like operation to perform.
 #[derive(TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
 #[repr(u32)]


### PR DESCRIPTION
Added `Mkdir` Hypercall.

The added fstat, stat & getdents hypercalls require a new version to be implemented in hermit.

This is blocked by #1390 (at least the definition of the hypercall should be part of this PR)