### PR TITLE
uhyve: Don't panic on interface version 3

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -176,7 +176,7 @@ pub(crate) fn generate_guest_start_address(
 				let (lb, ub) = range;
 				let hint = match interface_version.0 {
 					1 => " (More than 3GiB memory is not supported for Hermit <= 0.13.2)",
-					2 => "",
+					2 | 3 => "",
 					_ => unimplemented!(),
 				};
 				panic!("Out of range [{lb:#x}, {ub:#x}) due to memory size {mem_size:#x}.{hint}")


### PR DESCRIPTION
uhyve-interface version 3 (internal version number) does not change the memory layout or requirements.