### PR TITLE
Extract all layout related information into a MemoryLayout trait

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,13 +1,18 @@
-use std::mem::size_of;
+use std::{fmt::Display, mem::size_of};
 
 use align_address::Align;
 use bitflags::bitflags;
+use hermit_entry::{UhyveIfVersion, elf::KernelObject};
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 
 use crate::{
-	consts::{PAGETABLES_END, PAGETABLES_OFFSET},
 	mem::MmapMemory,
+	mem_layout::{
+		BootInfoSection, FdtSection, MemoryLayout, PagetableSection, Section, StackSection,
+		generate_guest_start_address,
+	},
 	paging::{BumpAllocator, PagetableError},
+	params::Params,
 };
 
 pub(crate) const RAM_START: GuestPhysAddr = GuestPhysAddr::new(0x1000_0000);
@@ -16,6 +21,7 @@ pub(crate) const V1_ADDR_RANGE: (u64, u64) = (RAM_START.as_u64(), V1_MAX_ADDR);
 pub(crate) const V2_ADDR_RANGE: (u64, u64) = (0x0001_0000_0000u64, 0x0010_0000_0000u64);
 
 const SIZE_4KIB: u64 = 0x1000;
+pub(crate) const GUEST_PAGE_SIZE: u64 = SIZE_4KIB;
 
 // PageTableEntry Flags
 /// Present + 4KiB + device memory + inner_sharable + accessed
@@ -51,8 +57,6 @@ const PAGE_MAP_BITS: usize = 9;
 
 /// A mask where PAGE_MAP_BITS are set to calculate a table index.
 const PAGE_MAP_MASK: u64 = 0x1FF;
-
-pub const PGT_OFFSET: u64 = 0x10000;
 
 pub(crate) const GICD_BASE_ADDRESS: u64 = 0x800_0000;
 pub(crate) const GICD_SIZE: usize = 0x10000;
@@ -176,63 +180,43 @@ pub(crate) fn virt_to_phys(
 	Ok(pte.address() + (addr.as_u64() & !((!0u64) << PAGE_BITS)))
 }
 
-pub fn init_guest_mem(
-	mem: &mut [u8],
-	guest_address: GuestPhysAddr,
-	length: u64,
-	_legacy_mapping: bool,
-) {
-	let mem_addr = std::ptr::addr_of_mut!(mem[0]);
+pub(crate) fn init_guest_mem(mem: &mut MmapMemory, layout: &Aarch64MemoryLayout, length: u64) {
+	const PT_SIZE: usize = 512 * size_of::<u64>();
+	assert!(mem.guest_addr() + mem.size() >= layout.pgt_address() + PT_SIZE);
 
-	assert!(mem.len() >= PGT_OFFSET as usize + 512 * size_of::<u64>());
-
-	let pgt_slice = unsafe {
-		std::slice::from_raw_parts_mut(mem_addr.offset(PGT_OFFSET as isize) as *mut u64, 512)
-	};
+	let pgt_slice = unsafe { mem.get_ref_mut::<[u64; 512]>(layout.pgt_address()).unwrap() };
 	pgt_slice.fill(0);
-	pgt_slice[511] = (guest_address + PGT_OFFSET) | PT_PT | PT_SELF;
+	pgt_slice[511] = layout.pgt_address() | PT_PT | PT_SELF;
 
 	let mut boot_frame_allocator = BumpAllocator::<SIZE_4KIB>::new(
-		guest_address + PAGETABLES_OFFSET,
-		(PAGETABLES_END - PAGETABLES_OFFSET) / SIZE_4KIB,
+		layout.pagetables().0.start(),
+		layout.pagetables().0.length as u64 / SIZE_4KIB,
 	);
 
 	// Hypercalls are MMIO reads/writes in the lowest 4KiB of address space.
 	// Thus, we need to provide pagetable entries for this region.
 	let pgd0_addr = boot_frame_allocator.allocate().unwrap().as_u64();
 	pgt_slice[0] = pgd0_addr | PT_PT;
-	let pgd0_slice = unsafe {
-		std::slice::from_raw_parts_mut(
-			mem_addr.offset((pgd0_addr - guest_address.as_u64()) as isize) as *mut u64,
-			512,
-		)
-	};
+
+	let pgd0_slice = unsafe { mem.get_ref_mut::<[u64; 512]>(pgd0_addr.into()).unwrap() };
 	pgd0_slice.fill(0);
 	let pud0_addr = boot_frame_allocator.allocate().unwrap().as_u64();
 	pgd0_slice[0] = pud0_addr | PT_PT;
 
-	let pud0_slice = unsafe {
-		std::slice::from_raw_parts_mut(
-			mem_addr.offset((pud0_addr - guest_address.as_u64()) as isize) as *mut u64,
-			512,
-		)
-	};
+	let pud0_slice = unsafe { mem.get_ref_mut::<[u64; 512]>(pud0_addr.into()).unwrap() };
 	pud0_slice.fill(0);
 	let pmd0_addr = boot_frame_allocator.allocate().unwrap().as_u64();
 	pud0_slice[0] = pmd0_addr | PT_PT;
 
-	let pmd0_slice = unsafe {
-		std::slice::from_raw_parts_mut(
-			mem_addr.offset((pmd0_addr - guest_address.as_u64()) as isize) as *mut u64,
-			512,
-		)
-	};
+	let pmd0_slice = unsafe { mem.get_ref_mut::<[u64; 512]>(pmd0_addr.into()).unwrap() };
 	pmd0_slice.fill(0);
 	// Hypercall/IO mapping
-	pmd0_slice[0] = guest_address | PT_MEM_CD;
+	pmd0_slice[0] = layout.guest_address() | PT_MEM_CD;
 
-	for frame_addr in (guest_address.align_down(SIZE_4KIB).as_u64()
-		..(guest_address + length).align_up(SIZE_4KIB).as_u64())
+	for frame_addr in (layout.guest_address().align_down(SIZE_4KIB).as_u64()
+		..(layout.guest_address() + length)
+			.align_up(SIZE_4KIB)
+			.as_u64())
 		.step_by(SIZE_4KIB as usize)
 	{
 		let frame_addr_usz = frame_addr as usize;
@@ -258,12 +242,7 @@ pub fn init_guest_mem(
 						false,
 					)
 				};
-				let pd_slice = unsafe {
-					core::slice::from_raw_parts_mut(
-						mem_addr.offset((pd_addr - guest_address.as_u64()) as isize) as *mut u64,
-						512,
-					)
-				};
+				let pd_slice = unsafe { mem.get_ref_mut::<[u64; 512]>(pd_addr.into()).unwrap() };
 				if new {
 					pd_slice.fill(0);
 					prev_slice[idx] = pd_addr | PT_PT;
@@ -282,5 +261,134 @@ pub fn init_guest_mem(
 				// and each 16 * 4 KByte area have the same access property
 				PT_MEM_CONTIGUOUS
 			};
+	}
+}
+
+/// aarch64 Memory Layout.
+///
+/// It looks as follows:
+///
+/// ```txt
+///     0x0000_0000 ┌──────────────────────────┐
+///                 │ Hypercalls               │
+///                 ├──────────────────────────┤
+///                 │ not present              │
+///                 │                          │
+///    guest_address├──────────────────────────┤ ▲ ▲ ▲ ▲
+///                 │                          │ │ │ │ │ FDT_OFFSET
+///                 ├──────────────────────────┤ │ │ │ ▼
+///                 │ Device Tree (FDT) (4KiB) │ │ │ │ BOOT_INFO_OFFSET
+///                 ├──────────────────────────┤ │ │ ▼
+///                 │ Boot Info         (1KiB) │ │ │
+///                 ├──────────────────────────┤ │ │
+///                 │                          │ │ │PAGETABLES_OFFSET
+///                 ├──────────────────────────┤ │ ▼
+///                 │                          │ │
+///                 │ Pagetables               │ │
+///                 │                          │ │
+///    stack_address├──────────────────────────┤ │
+///                 │ Stack                    │ │KERNEL_OFFSET
+///   kernel_address├──────────────────────────┤ ▼
+///                 │ Kernel                   │
+///   entry_point──►│                          │
+///                 │                          │
+///                 ├──────────────────────────┤
+///                 │ Kernel Memory            │
+///                 │                          │
+///                 └──────────────────────────┘
+/// ```
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Aarch64MemoryLayout {
+	guest_address: GuestPhysAddr,
+	kernel_address: GuestPhysAddr,
+}
+impl Aarch64MemoryLayout {
+	const FDT_OFFSET: u64 = 0x1000;
+	const FDT_SIZE: usize = 4 * PAGE_SIZE;
+	const BOOT_INFO_OFFSET: u64 = Self::FDT_OFFSET + Self::FDT_SIZE as u64;
+
+	const PAGETABLES_OFFSET: u64 = 0x11000;
+	const PAGETABLES_END: u64 = Self::KERNEL_OFFSET - Self::KERNEL_STACK_SIZE;
+	const KERNEL_STACK_SIZE: u64 = 0x8000;
+	pub(crate) const KERNEL_OFFSET: u64 = 0x40000;
+
+	pub const PGT_OFFSET: u64 = 0x10000;
+
+	pub fn pgt_address(&self) -> GuestPhysAddr {
+		self.guest_address() + Self::PGT_OFFSET
+	}
+}
+impl MemoryLayout for Aarch64MemoryLayout {
+	fn new(params: &Params, object: &KernelObject<'_>) -> Self {
+		let uhyve_interface_version = object
+			.uhyve_interface_version()
+			.unwrap_or(UhyveIfVersion(1));
+
+		let memory_size = params.memory_size.get();
+
+		let (guest_address, kernel_address) = generate_guest_start_address(
+			uhyve_interface_version,
+			params.aslr,
+			object.mem_size(),
+			object.start_addr(),
+			memory_size,
+			Self::KERNEL_OFFSET,
+		);
+
+		assert!(
+			kernel_address.as_u64() > Self::KERNEL_STACK_SIZE,
+			"there should be enough space for the boot stack before the kernel start address",
+		);
+
+		Self {
+			guest_address,
+			kernel_address,
+		}
+	}
+
+	fn guest_address(&self) -> GuestPhysAddr {
+		self.guest_address
+	}
+
+	fn stack(&self) -> StackSection {
+		StackSection(Section {
+			addr: self.kernel_address - Self::KERNEL_STACK_SIZE,
+			length: Self::KERNEL_STACK_SIZE as usize,
+		})
+	}
+
+	fn fdt(&self) -> FdtSection {
+		FdtSection(Section {
+			addr: self.guest_address + Self::FDT_OFFSET,
+			length: Self::FDT_SIZE,
+		})
+	}
+
+	fn boot_info(&self) -> BootInfoSection {
+		BootInfoSection(Section {
+			addr: self.guest_address + Self::BOOT_INFO_OFFSET,
+			length: PAGE_SIZE,
+		})
+	}
+
+	fn kernel_address(&self) -> GuestPhysAddr {
+		self.kernel_address
+	}
+
+	fn pagetables(&self) -> crate::mem_layout::PagetableSection {
+		PagetableSection(Section {
+			addr: self.guest_address + Self::PAGETABLES_OFFSET,
+			length: (Self::PAGETABLES_END - Self::PAGETABLES_OFFSET) as usize,
+		})
+	}
+}
+impl Display for Aarch64MemoryLayout {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		writeln!(f, "Memory Layout:")?;
+		writeln!(f, "guest_address:     {:12x}", self.guest_address())?;
+		writeln!(f, "boot_info_address: {:12x}", self.boot_info().0.addr)?;
+		writeln!(f, "fdt_address:       {:12x}", self.fdt().0.addr)?;
+		writeln!(f, "stack_address:     {:12x}", self.stack().0.addr)?;
+		writeln!(f, "kernel_address:    {:12x}", self.kernel_address())
 	}
 }

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -8,8 +8,8 @@ use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 use crate::{
 	mem::MmapMemory,
 	mem_layout::{
-		BootInfoSection, FdtSection, MemoryLayout, PagetableSection, Section, StackSection,
-		generate_guest_start_address,
+		BootInfoSection, FdtSection, KernelSection, MemoryLayout, PagetableSection, Section,
+		StackSection, generate_guest_start_address,
 	},
 	paging::{BumpAllocator, PagetableError},
 	params::Params,
@@ -301,6 +301,7 @@ pub(crate) fn init_guest_mem(mem: &mut MmapMemory, layout: &Aarch64MemoryLayout,
 pub(crate) struct Aarch64MemoryLayout {
 	guest_address: GuestPhysAddr,
 	kernel_address: GuestPhysAddr,
+	kernel_len: usize,
 }
 impl Aarch64MemoryLayout {
 	const FDT_OFFSET: u64 = 0x1000;
@@ -343,6 +344,7 @@ impl MemoryLayout for Aarch64MemoryLayout {
 		Self {
 			guest_address,
 			kernel_address,
+			kernel_len: object.mem_size(),
 		}
 	}
 
@@ -371,8 +373,11 @@ impl MemoryLayout for Aarch64MemoryLayout {
 		})
 	}
 
-	fn kernel_address(&self) -> GuestPhysAddr {
-		self.kernel_address
+	fn kernel(&self) -> KernelSection {
+		KernelSection(Section {
+			addr: self.kernel_address,
+			length: self.kernel_len,
+		})
 	}
 
 	fn pagetables(&self) -> crate::mem_layout::PagetableSection {
@@ -389,6 +394,11 @@ impl Display for Aarch64MemoryLayout {
 		writeln!(f, "boot_info_address: {:12x}", self.boot_info().0.addr)?;
 		writeln!(f, "fdt_address:       {:12x}", self.fdt().0.addr)?;
 		writeln!(f, "stack_address:     {:12x}", self.stack().0.addr)?;
-		writeln!(f, "kernel_address:    {:12x}", self.kernel_address())
+		writeln!(f, "kernel_address:    {:12x}", self.kernel().0.addr)?;
+		writeln!(
+			f,
+			"guest_heap:        {:12x}",
+			self.kernel().0.addr + self.kernel_len
+		)
 	}
 }

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -14,8 +14,8 @@ use x86_64::structures::paging::{
 use crate::{
 	mem::MmapMemory,
 	mem_layout::{
-		BootInfoSection, FdtSection, MemoryLayout, PagetableSection, Section, StackSection,
-		generate_guest_start_address,
+		BootInfoSection, FdtSection, KernelSection, MemoryLayout, PagetableSection, Section,
+		StackSection, generate_guest_start_address,
 	},
 	os::x86_64::kvm_cpu::KVM_32BIT_GAP_START,
 	paging::PagetableError,
@@ -111,6 +111,7 @@ pub(crate) fn virt_to_phys(
 pub(crate) struct X86_64MemoryLayout {
 	guest_address: GuestPhysAddr,
 	kernel_address: GuestPhysAddr,
+	kernel_len: usize,
 }
 impl X86_64MemoryLayout {
 	const FDT_OFFSET: u64 = 0x1000;
@@ -132,6 +133,7 @@ impl X86_64MemoryLayout {
 		Self {
 			guest_address: guest_addr,
 			kernel_address: guest_addr + Self::KERNEL_OFFSET,
+			kernel_len: 0x1000,
 		}
 	}
 
@@ -168,6 +170,7 @@ impl MemoryLayout for X86_64MemoryLayout {
 		Self {
 			guest_address,
 			kernel_address,
+			kernel_len: object.mem_size(),
 		}
 	}
 
@@ -196,8 +199,11 @@ impl MemoryLayout for X86_64MemoryLayout {
 		})
 	}
 
-	fn kernel_address(&self) -> GuestPhysAddr {
-		self.kernel_address
+	fn kernel(&self) -> KernelSection {
+		KernelSection(Section {
+			addr: self.kernel_address,
+			length: self.kernel_len,
+		})
 	}
 
 	fn pagetables(&self) -> crate::mem_layout::PagetableSection {
@@ -214,7 +220,12 @@ impl Display for X86_64MemoryLayout {
 		writeln!(f, "boot_info_address: {:12x}", self.boot_info().0.addr)?;
 		writeln!(f, "fdt_address:       {:12x}", self.fdt().0.addr)?;
 		writeln!(f, "stack_address:     {:12x}", self.stack().0.addr)?;
-		writeln!(f, "kernel_address:    {:12x}", self.kernel_address())
+		writeln!(f, "kernel_address:    {:12x}", self.kernel().0.addr)?;
+		writeln!(
+			f,
+			"guest_heap:        {:12x}",
+			self.kernel().0.addr + self.kernel_len
+		)
 	}
 }
 

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -1,19 +1,29 @@
 pub(crate) mod breakpoints;
-mod paging;
+pub(crate) mod paging;
 
+use std::fmt::Display;
+
+use hermit_entry::{UhyveIfVersion, elf::KernelObject};
 pub(crate) use paging::BOOT_GDT_MAX;
-use paging::initialize_pagetables;
 use uhyve_interface::{GuestPhysAddr, GuestVirtAddr};
 use x86_64::structures::paging::{
-	PageTable, PageTableIndex,
+	PageSize, PageTable, PageTableIndex, Size4KiB,
 	page_table::{FrameError, PageTableEntry},
 };
 
-use crate::{mem::MmapMemory, os::x86_64::kvm_cpu::KVM_32BIT_GAP_START, paging::PagetableError};
+use crate::{
+	mem::MmapMemory,
+	mem_layout::{
+		BootInfoSection, FdtSection, MemoryLayout, PagetableSection, Section, StackSection,
+		generate_guest_start_address,
+	},
+	os::x86_64::kvm_cpu::KVM_32BIT_GAP_START,
+	paging::PagetableError,
+	params::Params,
+};
 
-pub const PAGE_SIZE: usize = 0x1000;
-pub(crate) const GDT_OFFSET: u64 = 0x1000;
-pub(crate) const PML4_OFFSET: u64 = 0x10000;
+pub const PAGE_SIZE: usize = Size4KiB::SIZE as usize;
+pub const GUEST_PAGE_SIZE: u64 = 0x200000; /* 2 MB pages in guest */
 
 pub(crate) const RAM_START: GuestPhysAddr = GuestPhysAddr::new(0x0);
 // Right below 3 GiB, aka. 0xBFFF_FFFF
@@ -64,23 +74,157 @@ pub(crate) fn virt_to_phys(
 	Ok((entry.addr() + (addr.as_u64() & !((!0u64) << PAGE_BITS))).into())
 }
 
-pub fn init_guest_mem(
-	mem: &mut [u8],
+/// x86_64 Memory Layout.
+///
+/// It looks as follows:
+///
+/// ```txt
+///     0x0000_0000 ┌──────────────────────────┐
+///                 │ Hypercalls               │
+///                 ├──────────────────────────┤
+///                 │ not present              │
+///                 │                          │
+///    guest_address├──────────────────────────┤ ▲ ▲ ▲ ▲
+///                 │ GDT                      │ │ │ │ │ FDT_OFFSET
+///                 ├──────────────────────────┤ │ │ │ ▼
+///                 │ Device Tree (FDT) (4KiB) │ │ │ │ BOOT_INFO_OFFSET
+///                 ├──────────────────────────┤ │ │ ▼
+///                 │ Boot Info         (1KiB) │ │ │
+///                 ├──────────────────────────┤ │ │
+///                 │                          │ │ │PAGETABLES_OFFSET
+///                 ├──────────────────────────┤ │ ▼
+///                 │                          │ │
+///                 │ Pagetables               │ │
+///                 │                          │ │
+///    stack_address├──────────────────────────┤ │
+///                 │ Stack                    │ │KERNEL_OFFSET
+///   kernel_address├──────────────────────────┤ ▼
+///                 │ Kernel                   │
+///   entry_point──►│                          │
+///                 │                          │
+///                 ├──────────────────────────┤
+///                 │ Kernel Memory            │
+///                 │                          │
+///                 └──────────────────────────┘
+/// ```
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct X86_64MemoryLayout {
 	guest_address: GuestPhysAddr,
-	length: u64,
-	legacy_mapping: bool,
-) {
-	// TODO: we should maybe return an error on failure (e.g., the memory is too small)
-	initialize_pagetables(mem, guest_address, length, legacy_mapping);
+	kernel_address: GuestPhysAddr,
+}
+impl X86_64MemoryLayout {
+	const FDT_OFFSET: u64 = 0x1000;
+	const FDT_SIZE: usize = 4 * PAGE_SIZE;
+	const BOOT_INFO_OFFSET: u64 = Self::FDT_OFFSET + Self::FDT_SIZE as u64;
+
+	const PAGETABLES_OFFSET: u64 = 0x11000;
+	const PAGETABLES_END: u64 = Self::KERNEL_OFFSET - Self::KERNEL_STACK_SIZE;
+	const KERNEL_STACK_SIZE: u64 = 0x8000;
+	pub(crate) const KERNEL_OFFSET: u64 = 0x40000;
+
+	const GDT_OFFSET: u64 = 0x0;
+	const PML4_OFFSET: u64 = 0x10000;
+	#[cfg(test)]
+	const MIN_PHYSMEM_SIZE: usize = 0x43000;
+
+	#[cfg(test)]
+	fn simple_layout(guest_addr: GuestPhysAddr) -> Self {
+		Self {
+			guest_address: guest_addr,
+			kernel_address: guest_addr + Self::KERNEL_OFFSET,
+		}
+	}
+
+	pub fn pml4_address(&self) -> GuestPhysAddr {
+		self.guest_address() + Self::PML4_OFFSET
+	}
+
+	pub fn gdt_address(&self) -> GuestPhysAddr {
+		self.guest_address() + Self::GDT_OFFSET
+	}
+}
+impl MemoryLayout for X86_64MemoryLayout {
+	fn new(params: &Params, object: &KernelObject<'_>) -> Self {
+		let uhyve_interface_version = object
+			.uhyve_interface_version()
+			.unwrap_or(UhyveIfVersion(1));
+
+		let memory_size = params.memory_size.get();
+
+		let (guest_address, kernel_address) = generate_guest_start_address(
+			uhyve_interface_version,
+			params.aslr,
+			object.mem_size(),
+			object.start_addr(),
+			memory_size,
+			Self::KERNEL_OFFSET,
+		);
+
+		assert!(
+			kernel_address.as_u64() > Self::KERNEL_STACK_SIZE,
+			"there should be enough space for the boot stack before the kernel start address",
+		);
+
+		Self {
+			guest_address,
+			kernel_address,
+		}
+	}
+
+	fn guest_address(&self) -> GuestPhysAddr {
+		self.guest_address
+	}
+
+	fn stack(&self) -> StackSection {
+		StackSection(Section {
+			addr: self.kernel_address - Self::KERNEL_STACK_SIZE,
+			length: Self::KERNEL_STACK_SIZE as usize,
+		})
+	}
+
+	fn fdt(&self) -> FdtSection {
+		FdtSection(Section {
+			addr: self.guest_address + Self::FDT_OFFSET,
+			length: Self::FDT_SIZE,
+		})
+	}
+
+	fn boot_info(&self) -> BootInfoSection {
+		BootInfoSection(Section {
+			addr: self.guest_address + Self::BOOT_INFO_OFFSET,
+			length: PAGE_SIZE,
+		})
+	}
+
+	fn kernel_address(&self) -> GuestPhysAddr {
+		self.kernel_address
+	}
+
+	fn pagetables(&self) -> crate::mem_layout::PagetableSection {
+		PagetableSection(Section {
+			addr: self.guest_address + Self::PAGETABLES_OFFSET,
+			length: (Self::PAGETABLES_END - Self::PAGETABLES_OFFSET) as usize,
+		})
+	}
+}
+impl Display for X86_64MemoryLayout {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		writeln!(f, "Memory Layout:")?;
+		writeln!(f, "guest_address:     {:12x}", self.guest_address())?;
+		writeln!(f, "boot_info_address: {:12x}", self.boot_info().0.addr)?;
+		writeln!(f, "fdt_address:       {:12x}", self.fdt().0.addr)?;
+		writeln!(f, "stack_address:     {:12x}", self.stack().0.addr)?;
+		writeln!(f, "kernel_address:    {:12x}", self.kernel_address())
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use x86_64::structures::paging::PageTableFlags;
 
-	use super::{paging::MIN_PHYSMEM_SIZE, *};
-	use crate::consts::{PAGETABLES_END, PAGETABLES_OFFSET};
+	use super::*;
 
+	#[cfg(target_arch = "x86_64")]
 	#[test]
 	fn test_virt_to_phys() {
 		let _ = env_logger::builder()
@@ -90,43 +234,49 @@ mod tests {
 
 		let guest_address = GuestPhysAddr::new(0x11111000);
 
-		let mem = MmapMemory::new(MIN_PHYSMEM_SIZE * 2, guest_address, true, true);
+		let mut mem = MmapMemory::new(
+			X86_64MemoryLayout::MIN_PHYSMEM_SIZE * 2,
+			guest_address,
+			true,
+			true,
+		);
 		log::debug!("mmap memory created {mem:x?}");
 
-		init_guest_mem(
-			unsafe { mem.as_slice_mut() },
-			guest_address,
-			MIN_PHYSMEM_SIZE as u64 * 2,
+		let layout = X86_64MemoryLayout::simple_layout(guest_address);
+		crate::arch::x86_64::paging::initialize_pagetables(
+			&mut mem,
+			&layout,
+			X86_64MemoryLayout::MIN_PHYSMEM_SIZE as u64 * 2,
 			false,
 		);
 
 		// Get the address of the first entry in PML4 (the address of the PML4 itself)
 		let virt_addr = GuestVirtAddr::new(0xFFFFFFFFFFFFF000);
-		let p_addr = virt_to_phys(virt_addr, &mem, guest_address + PML4_OFFSET).unwrap();
-		assert_eq!(p_addr, guest_address + PML4_OFFSET);
+		let p_addr = virt_to_phys(virt_addr, &mem, layout.pml4_address()).unwrap();
+		assert_eq!(p_addr, layout.pml4_address());
 
 		// The last entry on the PML4 is the address of the PML4 with flags
 		let virt_addr = GuestVirtAddr::new(0xFFFFFFFFFFFFF000 | (4096 - 8));
-		let p_addr = virt_to_phys(virt_addr, &mem, guest_address + PML4_OFFSET).unwrap();
+		let p_addr = virt_to_phys(virt_addr, &mem, layout.pml4_address()).unwrap();
 		assert_eq!(
 			mem.read::<u64>(p_addr).unwrap(),
-			(guest_address + PML4_OFFSET).as_u64()
+			layout.pml4_address().as_u64()
 				| (PageTableFlags::PRESENT | PageTableFlags::WRITABLE).bits()
 		);
 
 		// the first entry on the 3rd level entry in the pagetables is the address of the boot pdpte
 		let virt_addr = GuestVirtAddr::new(0xFFFFFFFFFFE00000);
-		let p_addr = virt_to_phys(virt_addr, &mem, guest_address + PML4_OFFSET).unwrap();
-		assert!(p_addr.as_u64() - guest_address.as_u64() >= PAGETABLES_OFFSET);
-		assert!(p_addr.as_u64() - guest_address.as_u64() <= PAGETABLES_END);
+		let p_addr = virt_to_phys(virt_addr, &mem, layout.pml4_address()).unwrap();
+		assert!(p_addr >= layout.pagetables().0.start());
+		assert!(p_addr <= layout.pagetables().0.end());
 
 		// the idx2 entry on the 2rd level entry in the pagetables is the address of the boot pde
 		let idx2 = GuestVirtAddr::new(guest_address.as_u64()).p2_index();
 		let virt_addr = GuestVirtAddr::new(0xFFFFFFFFC0000000)
 			+ u64::from(idx2) * size_of::<PageTableEntry>() as u64;
-		let p_addr = virt_to_phys(virt_addr, &mem, guest_address + PML4_OFFSET).unwrap();
-		assert!(p_addr.as_u64() - guest_address.as_u64() >= PAGETABLES_OFFSET);
-		assert!(p_addr.as_u64() - guest_address.as_u64() <= PAGETABLES_END);
+		let p_addr = virt_to_phys(virt_addr, &mem, layout.pml4_address()).unwrap();
+		assert!(p_addr >= layout.pagetables().0.start());
+		assert!(p_addr <= layout.pagetables().0.end());
 		// That address points to a huge page
 		assert!(
 			PageTableFlags::from_bits_truncate(mem.read::<u64>(p_addr).unwrap()).contains(

--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -7,22 +7,14 @@ use x86_64::{
 	},
 };
 
-use super::{GDT_OFFSET, PAGE_SIZE, PML4_OFFSET};
 use crate::{
-	consts::{PAGETABLES_END, PAGETABLES_OFFSET},
-	paging::BumpAllocator,
-	vm::KERNEL_OFFSET,
+	mem::MmapMemory, mem_layout::MemoryLayout, paging::BumpAllocator, x86_64::X86_64MemoryLayout,
 };
 
 const BOOT_GDT_NULL: usize = 0;
 const BOOT_GDT_CODE: usize = 1;
 const BOOT_GDT_DATA: usize = 2;
 pub(crate) const BOOT_GDT_MAX: usize = 3;
-
-// The offset of the kernel in the memory.
-// Must be larger than BOOT_INFO_OFFSET + KERNEL_STACK_SIZE
-#[cfg(test)]
-pub(super) const MIN_PHYSMEM_SIZE: usize = 0x43000;
 
 // Constructor for a conventional segment GDT (or LDT) entry
 pub fn create_gdt_entry(flags: u64, base: u64, limit: u64) -> u64 {
@@ -65,59 +57,51 @@ unsafe impl PageTableFrameMapping for UhyvePageTableFrameMapper<'_> {
 /// `mem` and `GuestPhysAddr` must be 2MiB page aligned.
 /// length is the size of the identity mapped region in bytes.
 pub fn initialize_pagetables(
-	mem: &mut [u8],
-	guest_address: GuestPhysAddr,
+	mem: &mut MmapMemory,
+	layout: &X86_64MemoryLayout,
 	length: u64,
 	// TODO: deprecate the legacy_mapping option once hermit pre 0.10.0 isn't a thing anymore.
 	legacy_mapping: bool,
 ) {
+	let pagetable_layout = layout.pagetables().0;
 	assert!(
-		mem.len() >= PAGETABLES_OFFSET as usize + 2 * PAGE_SIZE,
-		"Insufficient memory for at least a single three-level pagetable mapping"
+		layout.pagetables().0.end() <= mem.guest_addr() + mem.size(),
+		"Insufficient memory for pagetable mapping"
 	);
-	let mem_addr = std::ptr::addr_of_mut!(mem[0]);
 
-	let (gdt_entry, pml4);
-	// Safety:
-	// We only operate in `mem`, which is plain bytes and we have ownership of
-	// these and it is asserted to be large enough.
-	unsafe {
-		gdt_entry = mem_addr
-			.add(GDT_OFFSET as usize)
-			.cast::<[u64; 3]>()
-			.as_mut()
-			.unwrap();
-
-		pml4 = mem_addr
-			.add(PML4_OFFSET as usize)
-			.cast::<PageTable>()
-			.as_mut()
-			.unwrap();
-	}
-
+	// Safety: we have ownership of mem and during the lifetime of this slice we don't create other references into the memory.
+	let gdt_entry = unsafe { mem.get_ref_mut::<[u64; 3]>(layout.gdt_address()).unwrap() };
 	// initialize GDT
 	gdt_entry[BOOT_GDT_NULL] = 0;
 	gdt_entry[BOOT_GDT_CODE] = create_gdt_entry(0xA09B, 0, 0xFFFFF);
 	gdt_entry[BOOT_GDT_DATA] = create_gdt_entry(0xC093, 0, 0xFFFFF);
 
+	let pml4 = unsafe { mem.get_ref_mut::<PageTable>(layout.pml4_address()).unwrap() };
 	// recursive pagetable setup
 	pml4[511].set_addr(
-		(guest_address + PML4_OFFSET).into(),
+		layout.pml4_address().into(),
 		PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
 	);
 
 	let mut boot_frame_allocator = BumpAllocator::new(
-		guest_address + PAGETABLES_OFFSET,
-		(PAGETABLES_END - PAGETABLES_OFFSET) / Size4KiB::SIZE,
+		layout.pagetables().0.start(),
+		pagetable_layout.length as u64 / Size4KiB::SIZE,
 	);
-	let page_mapper = UhyvePageTableFrameMapper { mem, guest_address };
+	let page_mapper = UhyvePageTableFrameMapper {
+		// Safety: we have ownership of mem and during the lifetime of this slice we don't create other references into the memory.
+		mem: unsafe {
+			mem.slice_at_mut(pagetable_layout.addr, pagetable_layout.length)
+				.unwrap()
+		},
+		guest_address: pagetable_layout.addr,
+	};
 	// Safety: pml4 is zero initialized and page_mapper operates in a correct environment
 	let mut pagetable_mapping = unsafe { MappedPageTable::new(pml4, page_mapper) };
 
 	let mapping_range = if legacy_mapping {
 		debug!("Legacy mapping of the initial memory");
-		let start_page = guest_address;
-		let kernel_start = VirtAddr::new((guest_address + KERNEL_OFFSET).as_u64());
+		let start_page = layout.guest_address();
+		let kernel_start = VirtAddr::new(layout.kernel_address().as_u64());
 		let end_page = Page::from_page_table_indices_2mib(
 			kernel_start.p4_index(),
 			kernel_start.p3_index(),
@@ -125,17 +109,18 @@ pub fn initialize_pagetables(
 		);
 		let end = u64::max(
 			end_page.start_address().as_u64(),
-			guest_address.as_u64() + length,
+			layout.guest_address().as_u64() + length,
 		);
 		start_page.as_u64()..=end
 	} else {
-		guest_address.as_u64()..=guest_address.as_u64() + length
+		layout.guest_address().as_u64()..=layout.guest_address().as_u64() + length
 	};
 
 	// Map the kernel
 	debug!(
-		"identity mapping from {guest_address:?} to {:?}",
-		guest_address + length
+		"identity mapping from {:?} to {:?}",
+		layout.guest_address(),
+		layout.guest_address() + length
 	);
 	for addr in mapping_range.step_by(Size2MiB::SIZE as usize) {
 		let ga = GuestPhysAddr::new(addr);
@@ -183,11 +168,7 @@ mod tests {
 	use uhyve_interface::GuestVirtAddr;
 
 	use super::*;
-	use crate::{
-		arch::GDT_OFFSET,
-		consts::{PAGETABLES_END, PAGETABLES_OFFSET},
-		mem::MmapMemory,
-	};
+	use crate::mem::MmapMemory;
 
 	#[test]
 	fn test_pagetable_initialization() {
@@ -202,25 +183,24 @@ mod tests {
 			GuestPhysAddr::new(0x111ff000),
 			GuestPhysAddr::new(0xe1120000),
 		];
+
 		for &guest_address in gaddrs.iter() {
 			println!("\n\n---------------------------------------");
 			println!("testing guest address {guest_address:?}");
-			let mem = MmapMemory::new(MIN_PHYSMEM_SIZE * 2, guest_address, true, true);
-			initialize_pagetables(
-				unsafe {
-					mem.slice_at_mut(guest_address, MIN_PHYSMEM_SIZE * 2)
-						.unwrap()
-				},
+			let mut mem = MmapMemory::new(
+				X86_64MemoryLayout::MIN_PHYSMEM_SIZE * 2,
 				guest_address,
-				0x20_0000 * 4,
-				false,
+				true,
+				true,
 			);
+			let layout = X86_64MemoryLayout::simple_layout(guest_address);
+			initialize_pagetables(&mut mem, &layout, 0x20_0000 * 4, false);
 
 			/// Checks if `address` is in the pagetables.
 			fn check_and_print(
 				address: GuestVirtAddr,
-				phys_addr_offset: GuestPhysAddr,
 				mem: &MmapMemory,
+				layout: &X86_64MemoryLayout,
 			) {
 				let idx4 = address.p4_index();
 				let idx3 = address.p3_index();
@@ -231,16 +211,14 @@ mod tests {
 					u16::from(idx3),
 					u16::from(idx2)
 				);
-				let pml4 = unsafe { mem.get_ref(phys_addr_offset + PML4_OFFSET).unwrap() };
+				let pml4 = unsafe { mem.get_ref(layout.pml4_address()).unwrap() };
 				pretty_print_pagetable(pml4);
 
 				// Check PDPTE address
 				let addr_pdpte = &pml4[idx4];
 				debug!("addr_ptpde: {addr_pdpte:?}");
-				assert!(
-					addr_pdpte.addr().as_u64() - phys_addr_offset.as_u64() >= PAGETABLES_OFFSET
-				);
-				assert!(addr_pdpte.addr().as_u64() - phys_addr_offset.as_u64() <= PAGETABLES_END);
+				assert!(addr_pdpte.addr().as_u64() >= layout.pagetables().0.start().as_u64());
+				assert!(addr_pdpte.addr().as_u64() <= layout.pagetables().0.end().as_u64());
 				assert!(
 					addr_pdpte
 						.flags()
@@ -250,8 +228,8 @@ mod tests {
 				let pdpte = unsafe { mem.get_ref(addr_pdpte.addr().into()).unwrap() };
 				pretty_print_pagetable(pdpte);
 				let addr_pde = &pdpte[idx3];
-				assert!(addr_pde.addr().as_u64() - phys_addr_offset.as_u64() >= PAGETABLES_OFFSET);
-				assert!(addr_pde.addr().as_u64() - phys_addr_offset.as_u64() <= PAGETABLES_END);
+				assert!(addr_pde.addr().as_u64() >= layout.pagetables().0.start().as_u64());
+				assert!(addr_pde.addr().as_u64() <= layout.pagetables().0.end().as_u64());
 				assert!(
 					addr_pde
 						.flags()
@@ -263,21 +241,17 @@ mod tests {
 				assert_eq!(pde[idx2].addr().as_u64(), address.as_u64());
 			}
 
-			check_and_print(
-				GuestVirtAddr::new(guest_address.as_u64()),
-				guest_address,
-				&mem,
-			);
+			check_and_print(GuestVirtAddr::new(guest_address.as_u64()), &mem, &layout);
 			check_and_print(
 				GuestVirtAddr::new(guest_address.as_u64() + 3 * 0x20_0000),
-				guest_address,
 				&mem,
+				&layout,
 			);
 
 			// Test GDT
 			let gdt_results = [0x0, 0xAF9B000000FFFF, 0xCF93000000FFFF];
 			for (i, res) in gdt_results.iter().enumerate() {
-				let gdt_addr = guest_address + GDT_OFFSET as usize + i * 8;
+				let gdt_addr = layout.gdt_address() + i * 8;
 				let gdt_entry = u64::from_le_bytes(unsafe {
 					mem.slice_at(gdt_addr, 8).unwrap().try_into().unwrap()
 				});

--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -101,7 +101,7 @@ pub fn initialize_pagetables(
 	let mapping_range = if legacy_mapping {
 		debug!("Legacy mapping of the initial memory");
 		let start_page = layout.guest_address();
-		let kernel_start = VirtAddr::new(layout.kernel_address().as_u64());
+		let kernel_start = VirtAddr::new(layout.kernel().0.addr.as_u64());
 		let end_page = Page::from_page_table_indices_2mib(
 			kernel_start.p4_index(),
 			kernel_start.p3_index(),

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,0 @@
-// guest_address + OFFSET
-pub const PAGETABLES_OFFSET: u64 = 0x11000;
-pub const PAGETABLES_END: u64 = 0x30000;
-
-pub const GUEST_PAGE_SIZE: u64 = 0x200000; /* 2 MB pages in guest */

--- a/src/gdb/base.rs
+++ b/src/gdb/base.rs
@@ -179,7 +179,7 @@ impl target_multithread::MultiThreadBase for GdbVcpuManager<DefaultBackend> {
 
 impl SectionOffsets for crate::gdb::GdbVcpuManager<DefaultBackend> {
 	fn get_section_offsets(&mut self) -> Result<Offsets<u64>, Self::Error> {
-		let offset = self.kernel_info.layout.kernel_address().as_u64();
+		let offset = self.kernel_info.layout.kernel().0.addr.as_u64();
 		Ok(Offsets::Sections {
 			text: offset,
 			data: offset,

--- a/src/gdb/base.rs
+++ b/src/gdb/base.rs
@@ -14,7 +14,7 @@ use gdbstub::{
 #[cfg(not(target_os = "macos"))]
 use uhyve_interface::GuestVirtAddr;
 
-use crate::{HypervisorError, gdb::GdbVcpuManager, vm::DefaultBackend};
+use crate::{HypervisorError, gdb::GdbVcpuManager, mem_layout::MemoryLayout, vm::DefaultBackend};
 #[cfg(not(target_os = "macos"))]
 use crate::{os::gdb::regs, vcpu::VirtualCPU, virt_to_phys};
 
@@ -179,7 +179,7 @@ impl target_multithread::MultiThreadBase for GdbVcpuManager<DefaultBackend> {
 
 impl SectionOffsets for crate::gdb::GdbVcpuManager<DefaultBackend> {
 	fn get_section_offsets(&mut self) -> Result<Offsets<u64>, Self::Error> {
-		let offset = self.kernel_info.kernel_address.as_u64();
+		let offset = self.kernel_info.layout.kernel_address().as_u64();
 		Ok(Offsets::Sections {
 			text: offset,
 			data: offset,

--- a/src/gdb/mod.rs
+++ b/src/gdb/mod.rs
@@ -382,7 +382,7 @@ pub struct GdbVcpuManager<Vm: VirtualizationBackend> {
 
 	pub(crate) peripherals:
 		Arc<VmPeripherals<<Vm as VirtualizationBackendInternal>::VirtioNetImpl>>,
-	pub(crate) kernel_info: Arc<KernelInfo>,
+	pub(crate) kernel_info: Arc<KernelInfo<Vm::MemLayout>>,
 	pub(crate) stops: async_channel::Receiver<MultiThreadStopReason<u64>>,
 	pub(crate) vcpus: Vec<VcpuWrapper<<Vm as VirtualizationBackendInternal>::VCPU>>,
 	/// This does look odd, but GDB appears to truncate thread-ids to 32bit

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -27,6 +27,7 @@ use crate::{
 		filemap::{Directory, Node, NodeStatRef, UhyveFileMap, UhyveMapLeaf},
 	},
 	mem::MmapMemory,
+	mem_layout::MemoryLayout,
 	net::NetworkBackend,
 	params::EnvVars,
 	vcpu::VcpuStopReason,
@@ -184,9 +185,9 @@ pub fn handle_hypercall_v2<N: NetworkBackend>(
 ///
 /// When a hypercall returns an error, or the hypercall is invalid, this function might panic
 /// (particularly on failing write calls).
-pub fn handle_hypercall_v1<N: NetworkBackend>(
+pub fn handle_hypercall_v1<N: NetworkBackend, L: MemoryLayout>(
 	peripherals: &VmPeripherals<N>,
-	kernel_info: &KernelInfo,
+	kernel_info: &KernelInfo<L>,
 	root_pt: impl FnOnce() -> HypervisorResult<GuestPhysAddr>,
 	hypercall: v1::Hypercall<'_>,
 ) -> Option<HypervisorResult<VcpuStopReason>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@ use thiserror::Error;
 extern crate log;
 
 mod arch;
-pub mod consts;
 mod fdt;
 mod gdb;
 mod hypercall;
 mod isolation;
 pub(crate) mod mem;
+mod mem_layout;
 pub(crate) mod net;
 #[cfg_attr(target_os = "linux", path = "linux/mod.rs")]
 #[cfg_attr(target_os = "macos", path = "macos/mod.rs")]

--- a/src/linux/x86_64/kvm_cpu.rs
+++ b/src/linux/x86_64/kvm_cpu.rs
@@ -7,20 +7,18 @@ use x86_64::registers::control::{Cr0Flags, Cr4Flags};
 
 use crate::{
 	HypervisorError, HypervisorResult,
-	arch::{BOOT_GDT_MAX, GDT_OFFSET, PML4_OFFSET},
+	arch::{BOOT_GDT_MAX, X86_64MemoryLayout, x86_64::paging::initialize_pagetables},
 	gdb::resume::ResumeMode,
 	hypercall,
 	mem::MmapMemory,
+	mem_layout::MemoryLayout,
 	os::{KVM, KickSignal, x86_64::virtio_device::KvmVirtioNetDevice},
 	params::{NetworkMode, Params},
 	pci::{IOBASE_U64, IOEND_U64, PciConfigurationAddress, PciDevice},
 	stats::{CpuStats, VmExit},
 	vcpu::{VcpuStopReason, VirtualCPU},
 	virtio::net::VirtioNetPciDevice,
-	vm::{
-		BOOT_INFO_OFFSET, KernelInfo, VirtualizationBackend, VirtualizationBackendInternal,
-		VmPeripherals,
-	},
+	vm::{KernelInfo, VirtualizationBackend, VirtualizationBackendInternal, VmPeripherals},
 };
 
 const CPUID_EXT_HYPERVISOR: u32 = 1 << 31;
@@ -83,12 +81,13 @@ pub struct KvmVm {
 impl VirtualizationBackendInternal for KvmVm {
 	type VCPU = KvmCpu;
 	type VirtioNetImpl = KvmVirtioNetDevice;
+	type MemLayout = X86_64MemoryLayout;
 	const NAME: &str = "KvmVm";
 
 	fn new_cpu(
 		&self,
 		id: usize,
-		kernel_info: Arc<KernelInfo>,
+		kernel_info: Arc<KernelInfo<Self::MemLayout>>,
 		enable_stats: bool,
 	) -> HypervisorResult<KvmCpu> {
 		let vcpu = self.vm_fd.create_vcpu(id as u64)?;
@@ -205,6 +204,15 @@ impl VirtualizationBackendInternal for KvmVm {
 		})
 	}
 
+	fn init_guest_mem(
+		mem: &mut MmapMemory,
+		layout: &Self::MemLayout,
+		memory_size: u64,
+		legacy_mapping: bool,
+	) {
+		initialize_pagetables(mem, layout, memory_size, legacy_mapping);
+	}
+
 	fn virtio_net_device(mode: NetworkMode, memory: Arc<MmapMemory>) -> Self::VirtioNetImpl {
 		KvmVirtioNetDevice::new(VirtioNetPciDevice::new(mode, memory))
 	}
@@ -217,7 +225,7 @@ pub struct KvmCpu {
 	vcpu: VcpuFd,
 	peripherals: Arc<VmPeripherals<<KvmVm as VirtualizationBackendInternal>::VirtioNetImpl>>,
 	// TODO: Remove once the getenv/getargs hypercalls are removed
-	kernel_info: Arc<KernelInfo>,
+	kernel_info: Arc<KernelInfo<<KvmVm as VirtualizationBackendInternal>::MemLayout>>,
 	pci_addr: Option<u32>,
 	stats: Option<CpuStats>,
 }
@@ -226,8 +234,7 @@ impl KvmCpu {
 	fn init(&mut self) -> HypervisorResult<()> {
 		self.setup_long_mode(
 			self.kernel_info.entry_point,
-			self.kernel_info.stack_address,
-			self.kernel_info.guest_address,
+			self.kernel_info.layout,
 			self.id,
 		)?;
 		self.setup_cpuid()?;
@@ -348,8 +355,7 @@ impl KvmCpu {
 	fn setup_long_mode(
 		&self,
 		entry_point: GuestPhysAddr,
-		stack_address: GuestPhysAddr,
-		guest_address: GuestPhysAddr,
+		layout: X86_64MemoryLayout,
 		cpu_id: usize,
 	) -> Result<(), kvm_ioctls::Error> {
 		let mut sregs = self.vcpu.get_sregs()?;
@@ -360,7 +366,7 @@ impl KvmCpu {
 			| Cr0Flags::PAGING;
 		sregs.cr0 = cr0.bits();
 
-		sregs.cr3 = (guest_address + PML4_OFFSET).as_u64();
+		sregs.cr3 = layout.pml4_address().as_u64();
 
 		let cr4 = Cr4Flags::PHYSICAL_ADDRESS_EXTENSION;
 		sregs.cr4 = cr4.bits();
@@ -391,16 +397,16 @@ impl KvmCpu {
 		// Read-Write, accessed. L bit must not be set.
 		(seg.type_, seg.selector, seg.l) = (3, 1 << 4, 0);
 		(sregs.ds, sregs.es, sregs.ss) = (seg, seg, seg);
-		sregs.gdt.base = (guest_address + GDT_OFFSET).as_u64();
+		sregs.gdt.base = layout.gdt_address().as_u64();
 		sregs.gdt.limit = ((std::mem::size_of::<u64>() * BOOT_GDT_MAX) - 1) as u16;
 		self.vcpu.set_sregs(&sregs)?;
 
 		let regs = kvm_regs {
 			rflags: 2,
 			rip: entry_point.as_u64(),
-			rdi: (guest_address + BOOT_INFO_OFFSET).as_u64(),
+			rdi: layout.boot_info().0.addr.as_u64(),
 			rsi: cpu_id.try_into().unwrap(),
-			rsp: stack_address.as_u64(),
+			rsp: layout.stack().0.addr.as_u64(),
 			..Default::default()
 		};
 		self.vcpu.set_regs(&regs)?;

--- a/src/macos/aarch64/vcpu.rs
+++ b/src/macos/aarch64/vcpu.rs
@@ -10,20 +10,18 @@ use xhypervisor::{
 use crate::{
 	HypervisorError, HypervisorResult,
 	arch::{
-		GICD_BASE_ADDRESS, GICR_BASE_ADDRESS, MSI_BASE_ADDRESS, MT_DEVICE_GRE, MT_DEVICE_nGnRE,
-		MT_DEVICE_nGnRnE, MT_NORMAL, MT_NORMAL_NC, PGT_OFFSET, PSR, TCR_FLAGS, TCR_TG1_4K, VA_BITS,
-		mair, tcr_size,
+		Aarch64MemoryLayout, GICD_BASE_ADDRESS, GICR_BASE_ADDRESS, MSI_BASE_ADDRESS, MT_DEVICE_GRE,
+		MT_DEVICE_nGnRE, MT_DEVICE_nGnRnE, MT_NORMAL, MT_NORMAL_NC, PSR, TCR_FLAGS, TCR_TG1_4K,
+		VA_BITS, init_guest_mem, mair, tcr_size,
 	},
 	hypercall,
 	mem::MmapMemory,
+	mem_layout::MemoryLayout,
 	os::aarch64::virtio_device::XHyveVirtioNetDevice,
 	params::{NetworkMode, Params},
 	stats::CpuStats,
 	vcpu::{VcpuStopReason, VirtualCPU},
-	vm::{
-		BOOT_INFO_OFFSET, KernelInfo, VirtualizationBackend, VirtualizationBackendInternal,
-		VmPeripherals,
-	},
+	vm::{KernelInfo, VirtualizationBackend, VirtualizationBackendInternal, VmPeripherals},
 };
 
 pub struct XhyveVm {
@@ -37,12 +35,13 @@ pub struct XhyveVm {
 impl VirtualizationBackendInternal for XhyveVm {
 	type VCPU = XhyveCpu;
 	type VirtioNetImpl = XHyveVirtioNetDevice;
+	type MemLayout = Aarch64MemoryLayout;
 	const NAME: &str = "XhyveVm";
 
 	fn new_cpu(
 		&self,
 		id: usize,
-		kernel_info: Arc<KernelInfo>,
+		kernel_info: Arc<KernelInfo<Self::MemLayout>>,
 		enable_stats: bool,
 	) -> HypervisorResult<XhyveCpu> {
 		Ok(XhyveCpu {
@@ -81,6 +80,15 @@ impl VirtualizationBackendInternal for XhyveVm {
 		Ok(Self { peripherals, gic })
 	}
 
+	fn init_guest_mem(
+		mem: &mut MmapMemory,
+		layout: &Self::MemLayout,
+		memory_size: u64,
+		_legacy_mapping: bool,
+	) {
+		init_guest_mem(mem, layout, memory_size)
+	}
+
 	fn virtio_net_device(_mode: NetworkMode, _memory: Arc<MmapMemory>) -> Self::VirtioNetImpl {
 		unimplemented!();
 	}
@@ -93,7 +101,7 @@ pub struct XhyveCpu {
 	vcpu: Option<xhypervisor::VirtualCpu>,
 	peripherals: Arc<VmPeripherals<<XhyveVm as VirtualizationBackendInternal>::VirtioNetImpl>>,
 	// TODO: Remove once the getenv/getargs hypercalls are removed
-	kernel_info: Arc<KernelInfo>,
+	kernel_info: Arc<KernelInfo<<XhyveVm as VirtualizationBackendInternal>::MemLayout>>,
 	stats: Option<CpuStats>,
 }
 
@@ -109,8 +117,7 @@ impl VirtualCPU for XhyveCpu {
 
 		let KernelInfo {
 			entry_point,
-			stack_address,
-			guest_address,
+			layout,
 			..
 		} = &*self.kernel_info;
 
@@ -121,8 +128,8 @@ impl VirtualCPU for XhyveCpu {
 		let pstate: PSR = PSR::D_BIT | PSR::A_BIT | PSR::I_BIT | PSR::F_BIT | PSR::MODE_EL1H;
 		vcpu.write_register(Register::CPSR, pstate.bits())?;
 		vcpu.write_register(Register::PC, entry_point.as_u64())?;
-		vcpu.write_system_register(SystemRegister::SP_EL1, stack_address.as_u64())?;
-		vcpu.write_register(Register::X0, (*guest_address + BOOT_INFO_OFFSET).as_u64())?;
+		vcpu.write_system_register(SystemRegister::SP_EL1, layout.stack().0.addr.as_u64())?;
+		vcpu.write_register(Register::X0, (layout.boot_info().0.addr).as_u64())?;
 		vcpu.write_register(Register::X1, self.id.into())?;
 
 		/*
@@ -166,10 +173,7 @@ impl VirtualCPU for XhyveCpu {
 
 		// Load TTBRx
 		vcpu.write_system_register(SystemRegister::TTBR1_EL1, 0)?;
-		vcpu.write_system_register(
-			SystemRegister::TTBR0_EL1,
-			(*guest_address + PGT_OFFSET).as_u64(),
-		)?;
+		vcpu.write_system_register(SystemRegister::TTBR0_EL1, layout.pgt_address().as_u64())?;
 
 		/*
 		* Prepare system control register (SCTRL)
@@ -236,7 +240,7 @@ impl VirtualCPU for XhyveCpu {
 							if let Some(hypercall) = unsafe {
 								hypercall::address_to_hypercall_v2(
 									&self.peripherals.mem,
-									addr - self.kernel_info.guest_address.as_u64(),
+									addr - self.kernel_info.layout.guest_address().as_u64(),
 									data_addr,
 								)
 							} {
@@ -252,7 +256,7 @@ impl VirtualCPU for XhyveCpu {
 							} else if let Some(hypercall) = unsafe {
 								hypercall::address_to_hypercall_v1(
 									&self.peripherals.mem,
-									(addr - self.kernel_info.guest_address.as_u64())
+									(addr - self.kernel_info.layout.guest_address().as_u64())
 										.try_into()
 										.unwrap(),
 									data_addr,

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,4 +1,4 @@
-use std::{mem::MaybeUninit, ops::Range};
+use std::ops::Range;
 #[cfg(target_os = "linux")]
 use std::{os::raw::c_void, ptr::NonNull};
 
@@ -10,6 +10,8 @@ use vm_memory::{
 	Address, GuestAddress, GuestMemoryBackend, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
 	MemoryRegionAddress, mmap::MmapRegionBuilder,
 };
+
+use crate::mem_layout::Section;
 
 #[derive(Error, Debug)]
 pub enum MemoryError {
@@ -112,16 +114,6 @@ impl MmapMemory {
 	#[expect(clippy::mut_from_ref)]
 	pub unsafe fn as_slice_mut(&self) -> &mut [u8] {
 		unsafe { std::slice::from_raw_parts_mut(self.host_start(), self.size()) }
-	}
-
-	/// # Safety
-	///
-	/// Same as [`as_slice_mut`], but for `MaybeUninit<u8>`. Actually the memory is initialized, as Mmap zero initializes it, but some fns like [`hermit_entry::elf::load_kernel`] require [`MaybeUninit`]s.
-	#[expect(clippy::mut_from_ref)]
-	pub unsafe fn as_slice_uninit_mut(&self) -> &mut [MaybeUninit<u8>] {
-		unsafe {
-			std::slice::from_raw_parts_mut(self.host_start() as *mut MaybeUninit<u8>, self.size())
-		}
 	}
 
 	/// Converts `addr` to a `MemoryRegionAddress` that is relative to the internally used memory.
@@ -255,6 +247,20 @@ impl MmapMemory {
 	// TODO: Eliminate usages in favor of `address_range`
 	pub fn address_range_u64(&self) -> Range<u64> {
 		self.guest_addr().as_u64()..self.guest_addr().as_u64() + self.size() as u64
+	}
+
+	/// Convenience wrapper around [`slice_at`] to work directly on [`Section`]s. Same safety rules apply.
+	#[expect(dead_code)] // not yet used.
+	pub unsafe fn section_slice<T>(&self, section: Section) -> Result<&[T], MemoryError> {
+		assert_eq!(section.length % size_of::<T>(), 0);
+		unsafe { self.slice_at(section.start(), section.length / size_of::<T>()) }
+	}
+
+	/// Convenience wrapper around [`slice_at_mut`] to work directly on [`Section`]s. Same safety rules apply.
+	#[expect(clippy::mut_from_ref)]
+	pub unsafe fn section_slice_mut<T>(&self, section: Section) -> Result<&mut [T], MemoryError> {
+		assert_eq!(section.length % size_of::<T>(), 0);
+		unsafe { self.slice_at_mut(section.start(), section.length / size_of::<T>()) }
 	}
 }
 

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -149,16 +149,17 @@ impl MmapMemory {
 	///
 	/// # Safety
 	///
-	/// This is unsafe, as can create multiple aliasing. During the lifetime of
-	/// the returned slice, the memory must not be altered to prevent undfined
-	/// behaviour.
-	pub unsafe fn slice_at(&self, addr: GuestPhysAddr, len: usize) -> Result<&[u8], MemoryError> {
+	/// - This can create multiple aliasing. During the lifetime of the returned slice, the memory must
+	///   not be altered to prevent undfined behaviour.
+	/// - `addr` must have proper alignment of `T`
+	pub unsafe fn slice_at<T>(&self, addr: GuestPhysAddr, len: usize) -> Result<&[T], MemoryError> {
 		let guest_addr = self.addr_to_mem_region_addr(addr)?;
-		if self.check_range(guest_addr, len)? {
+		let len_bytes = len * size_of::<T>();
+		if self.check_range(guest_addr, len_bytes)? {
 			Ok(unsafe {
 				std::slice::from_raw_parts_mut(
-					self.region_mmap().get_host_address(guest_addr).unwrap(),
-					len,
+					self.region_mmap().get_host_address(guest_addr).unwrap() as *mut T,
+					len_bytes,
 				)
 			})
 		} else {
@@ -170,21 +171,22 @@ impl MmapMemory {
 	///
 	/// # Safety
 	///
-	/// This is unsafe, as it can create multiple aliasing. During the lifetime of
-	/// the returned slice, the memory must not be altered to prevent undfined
-	/// behavior.
+	/// - This can create multiple aliasing. During the lifetime of the returned slice, the memory must
+	///   not be altered to prevent undfined behaviour.
+	/// - `addr` must have proper alignment of `T`
 	#[expect(clippy::mut_from_ref)]
-	pub unsafe fn slice_at_mut(
+	pub unsafe fn slice_at_mut<T>(
 		&self,
 		addr: GuestPhysAddr,
 		len: usize,
-	) -> Result<&mut [u8], MemoryError> {
+	) -> Result<&mut [T], MemoryError> {
 		let guest_addr = self.addr_to_mem_region_addr(addr)?;
-		if self.check_range(guest_addr, len)? {
+		let len_bytes = len * size_of::<T>();
+		if self.check_range(guest_addr, len_bytes)? {
 			Ok(unsafe {
 				std::slice::from_raw_parts_mut(
-					self.region_mmap().get_host_address(guest_addr).unwrap(),
-					len,
+					self.region_mmap().get_host_address(guest_addr).unwrap() as *mut T,
+					len_bytes,
 				)
 			})
 		} else {

--- a/src/mem_layout.rs
+++ b/src/mem_layout.rs
@@ -19,7 +19,6 @@ impl Section {
 		self.addr
 	}
 	// "no code using it on aarch64 (yet)"
-	#[cfg_attr(target_arch = "aarch64", expect(dead_code))]
 	pub fn end(&self) -> GuestPhysAddr {
 		self.addr + self.length
 	}
@@ -29,6 +28,7 @@ pub(crate) struct FdtSection(pub Section);
 pub(crate) struct BootInfoSection(pub Section);
 pub(crate) struct StackSection(pub Section);
 pub(crate) struct PagetableSection(pub Section);
+pub(crate) struct KernelSection(pub Section);
 
 pub trait MemoryLayout: Display + Debug {
 	fn new(params: &Params, object: &KernelObject<'_>) -> Self;
@@ -36,8 +36,8 @@ pub trait MemoryLayout: Display + Debug {
 	/// The location of the whole guest in the physical address space
 	fn guest_address(&self) -> GuestPhysAddr;
 
-	/// The starting position of the image in physical memory
-	fn kernel_address(&self) -> GuestPhysAddr;
+	/// The location of the kernel image in physical memory
+	fn kernel(&self) -> KernelSection;
 
 	fn stack(&self) -> StackSection;
 

--- a/src/mem_layout.rs
+++ b/src/mem_layout.rs
@@ -1,0 +1,253 @@
+use std::{
+	fmt::{Debug, Display},
+	ops::Add,
+};
+
+use align_address::Align;
+use hermit_entry::{UhyveIfVersion, elf::KernelObject};
+use uhyve_interface::GuestPhysAddr;
+
+use crate::{V1_ADDR_RANGE, V2_ADDR_RANGE, params::Params};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Section {
+	pub addr: GuestPhysAddr,
+	pub length: usize,
+}
+impl Section {
+	pub fn start(&self) -> GuestPhysAddr {
+		self.addr
+	}
+	// "no code using it on aarch64 (yet)"
+	#[cfg_attr(target_arch = "aarch64", expect(dead_code))]
+	pub fn end(&self) -> GuestPhysAddr {
+		self.addr + self.length
+	}
+}
+
+pub(crate) struct FdtSection(pub Section);
+pub(crate) struct BootInfoSection(pub Section);
+pub(crate) struct StackSection(pub Section);
+pub(crate) struct PagetableSection(pub Section);
+
+pub trait MemoryLayout: Display + Debug {
+	fn new(params: &Params, object: &KernelObject<'_>) -> Self;
+
+	/// The location of the whole guest in the physical address space
+	fn guest_address(&self) -> GuestPhysAddr;
+
+	/// The starting position of the image in physical memory
+	fn kernel_address(&self) -> GuestPhysAddr;
+
+	fn stack(&self) -> StackSection;
+
+	fn fdt(&self) -> FdtSection;
+
+	fn boot_info(&self) -> BootInfoSection;
+
+	/// The Starting position of the allocatable pagetables area. This doesn't need to include the root pagetable.
+	fn pagetables(&self) -> PagetableSection;
+}
+
+/// Returns a guest & start address tuple based on the object file.
+///
+/// Generates a tuple containing a potentially random guest address and a derived
+/// start address for Uhyve's virtualized memory. The guest address will not be
+/// random under the following conditions:
+/// - The image is not relocatable / uses uhyve-interface v1.
+/// - ASLR is disabled.
+///
+/// If the image is not relocatable, the start address will be equal to that
+/// present in the unikernel image file's object representation.
+///
+/// - `interface_version`: Version of uhyve-interface.
+/// - `aslr`: `bool` describing whether ASLR is enabled (`true`) or disabled (`false`).
+/// - `object_mem_size`: Memory required to load the object file onto the guest's memory.
+/// - `object_start_addr`: Start address embedded in the unikernel image (if applicable).
+/// - `mem_size`: User-defined memory size that should be available to the VM.
+pub(crate) fn generate_guest_start_address(
+	interface_version: UhyveIfVersion,
+	aslr: bool,
+	object_mem_size: usize,
+	object_start_addr: Option<u64>,
+	mem_size: usize,
+	kernel_offset: u64,
+) -> (GuestPhysAddr, GuestPhysAddr) {
+	// Using an interface-specific version's range and by using checked_sub, we
+	// guarantee that the range used during the kernel's execution won't lead
+	// to a boundary violation during the guest's execution.
+	let (guest_address_lb, guest_address_ub): (u64, u64) = {
+		let range = match interface_version.0 {
+			1 => V1_ADDR_RANGE,
+			2 | 3 => V2_ADDR_RANGE,
+			_ => unimplemented!(),
+		};
+		// kernel_offset will be added again later for the start address, later.
+		let mem_size = (object_mem_size + mem_size) as u64 + kernel_offset;
+		(
+			range.0,
+			range.1.checked_sub(mem_size).unwrap_or_else(|| {
+				let (lb, ub) = range;
+				let hint = match interface_version.0 {
+					1 => " (More than 3GiB memory is not supported for Hermit <= 0.13.2)",
+					2 | 3 => "",
+					_ => unimplemented!(),
+				};
+				panic!("Out of range [{lb:#x}, {ub:#x}) due to memory size {mem_size:#x}.{hint}")
+			}),
+		)
+	};
+
+	debug_assert!(guest_address_lb <= guest_address_ub);
+
+	match (aslr, object_start_addr) {
+		(true, None) => {
+			let mut rng = rand::rng();
+			let guest_address = GuestPhysAddr::new(
+				rand::RngExt::random_range(&mut rng, guest_address_lb..=guest_address_ub)
+					.align_down(0x20_0000),
+			);
+			(guest_address, guest_address.add(kernel_offset))
+		}
+		(false, None) => {
+			let guest_address = GuestPhysAddr::new(guest_address_lb);
+			(guest_address, guest_address.add(kernel_offset))
+		}
+		(_, Some(predefined_start_address)) => {
+			assert!(
+				(guest_address_lb..=guest_address_ub).contains(&predefined_start_address),
+				"Predefined address {predefined_start_address:#x} out of range of possible
+				 guest addresses: [{guest_address_lb:#x}, {guest_address_ub:#x}]."
+			);
+			if aslr {
+				warn!("ASLR is enabled but kernel is not relocatable - disabling ASLR");
+			}
+			(
+				GuestPhysAddr::new(guest_address_lb),
+				GuestPhysAddr::new(predefined_start_address),
+			)
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::ops::Add;
+
+	use hermit_entry::UhyveIfVersion;
+
+	use super::*;
+	use crate::{RAM_START, V1_MAX_ADDR};
+
+	#[test]
+	fn test_generate_guest_start_address() {
+		#![cfg_attr(target_arch = "aarch64", allow(unused_assignments))]
+		let mem_size: usize = 0xBE20_0000; // 3042 MiB
+		let if_v1 = UhyveIfVersion(1);
+		let if_v2 = UhyveIfVersion(2);
+		let object_mem_size: usize = 0x0009_C400;
+		let object_no_start_addr: Option<u64> = None;
+		#[cfg(target_arch = "x86_64")]
+		let object_start_addr: u64 = 0x0002_0000;
+		#[cfg(target_arch = "aarch64")]
+		let object_start_addr: u64 = 0x1002_0000;
+		let kernel_offset = 0x004_0000;
+
+		/* v1 */
+		// v1: No ASLR, relocatable
+		let (mut guest_address, mut start_address) = generate_guest_start_address(
+			if_v1,
+			false,
+			object_mem_size,
+			object_no_start_addr,
+			mem_size,
+			kernel_offset,
+		);
+		assert!(guest_address < start_address);
+		assert_eq!(guest_address, RAM_START);
+
+		// v1: ASLR, relocatable
+		(guest_address, start_address) = generate_guest_start_address(
+			if_v1,
+			true,
+			object_mem_size,
+			object_no_start_addr,
+			mem_size,
+			kernel_offset,
+		);
+		assert!(guest_address < start_address);
+		assert!(start_address.as_u64() <= V1_MAX_ADDR);
+
+		// v1: ASLR, non-relocatable
+		(guest_address, start_address) = generate_guest_start_address(
+			if_v1,
+			true,
+			object_mem_size,
+			object_start_addr.into(),
+			mem_size,
+			kernel_offset,
+		);
+		assert!(guest_address < start_address);
+		assert_eq!(guest_address, RAM_START);
+		assert_eq!(start_address.as_u64(), object_start_addr);
+		// Note that this is a bit brittle and implicitly relies on RAM_START.
+		assert_eq!(start_address, guest_address.add(0x0002_0000usize));
+		assert!(start_address.as_u64() <= V1_MAX_ADDR);
+
+		/* v2 */
+
+		// v2: No ASLR, relocatable
+		(guest_address, start_address) = generate_guest_start_address(
+			if_v2,
+			false,
+			object_mem_size,
+			object_no_start_addr,
+			mem_size,
+			kernel_offset,
+		);
+		assert_eq!(guest_address.as_u64(), 0x0001_0000_0000u64);
+		#[cfg(target_arch = "x86_64")]
+		assert!(start_address.as_u64() >= V1_MAX_ADDR);
+
+		// v2: ASLR, relocatable
+		(guest_address, start_address) = generate_guest_start_address(
+			if_v2,
+			true,
+			object_mem_size,
+			object_no_start_addr,
+			mem_size,
+			kernel_offset,
+		);
+		#[cfg(target_arch = "x86_64")]
+		assert!(start_address.as_u64() >= V1_MAX_ADDR);
+		assert_ne!(guest_address.as_u64(), 0x0);
+
+		// v2: Use entire memory available
+		//
+		// (This effectively renders ASLR worthless, yet it is great for testing,
+		//  underlying arithmetic operations for potential regressions without
+		//  exclusively relying on randomness!)
+		(guest_address, start_address) = generate_guest_start_address(
+			if_v2,
+			true,
+			object_mem_size,
+			object_no_start_addr,
+			// Highest address, minus everything that is subtracted from it in the function.
+			0x0010_0000_0000 - object_mem_size - kernel_offset as usize - 0x0001_0000_0000,
+			kernel_offset,
+		);
+		assert_eq!(guest_address.as_u64(), 0x0001_0000_0000);
+		#[cfg(target_arch = "x86_64")]
+		assert_eq!(
+			start_address,
+			guest_address.add(crate::arch::x86_64::X86_64MemoryLayout::KERNEL_OFFSET)
+		);
+		#[cfg(target_arch = "aarch64")]
+		assert_eq!(
+			start_address,
+			guest_address.add(crate::arch::aarch64::Aarch64MemoryLayout::KERNEL_OFFSET)
+		);
+		#[cfg(target_arch = "x86_64")]
+		assert!(start_address.as_u64() >= V1_MAX_ADDR);
+	}
+}

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -7,7 +7,7 @@ use uhyve_interface::GuestPhysAddr;
 use zerocopy::{Immutable, IntoBytes};
 
 use crate::{
-	consts::GUEST_PAGE_SIZE,
+	arch::GUEST_PAGE_SIZE,
 	net::{PCI_ETHERNET_REVISION_ID, UHYVE_PCI_CLASS_INFO},
 	virtio::{DeviceStatus, VIRTIO_VENDOR_ID},
 };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -6,7 +6,6 @@ use std::{
 	fs, io,
 	mem::{drop, take},
 	num::NonZero,
-	ops::Add,
 	path::PathBuf,
 	sync::{Arc, Barrier, Mutex},
 	thread,
@@ -28,11 +27,12 @@ use thiserror::Error;
 use uhyve_interface::GuestPhysAddr;
 
 use crate::{
-	HypervisorError, PAGE_SIZE, V1_ADDR_RANGE, V2_ADDR_RANGE,
+	HypervisorError, PAGE_SIZE,
 	fdt::Fdt,
 	gdb::GdbVcpuManager,
 	isolation::filemap::{UhyveFileMap, UhyveMapLeaf},
 	mem::MmapMemory,
+	mem_layout::{BootInfoSection, FdtSection, MemoryLayout},
 	net::NetworkBackend,
 	params::{EnvVars, HermitImageMode, NetworkMode, Params},
 	parking::Parker,
@@ -69,13 +69,15 @@ pub type DefaultBackend = crate::os::XhyveVm;
 pub(crate) trait VirtualizationBackendInternal: Sized {
 	type VCPU: 'static + VirtualCPU;
 	type VirtioNetImpl: NetworkBackend;
+	type MemLayout: MemoryLayout + Copy;
+
 	const NAME: &str;
 
 	/// Create a new CPU object
 	fn new_cpu(
 		&self,
 		id: usize,
-		kernel_info: Arc<KernelInfo>,
+		kernel_info: Arc<KernelInfo<Self::MemLayout>>,
 		enable_stats: bool,
 	) -> HypervisorResult<Self::VCPU>;
 
@@ -83,6 +85,16 @@ pub(crate) trait VirtualizationBackendInternal: Sized {
 		peripherals: Arc<VmPeripherals<Self::VirtioNetImpl>>,
 		params: &Params,
 	) -> HypervisorResult<Self>;
+
+	/// Initialize the page tables for the guest
+	/// `memory_size` is the length of the memory from the start of the physical
+	/// memory till the end of the kernel in bytes.
+	fn init_guest_mem(
+		mem: &mut MmapMemory,
+		layout: &Self::MemLayout,
+		memory_size: u64,
+		legacy_mapping: bool,
+	);
 
 	fn virtio_net_device(mode: NetworkMode, mmap: Arc<MmapMemory>) -> Self::VirtioNetImpl;
 }
@@ -115,111 +127,25 @@ unsafe impl<N: NetworkBackend> Sync for VmPeripherals<N> {}
 
 /// static information that does not change during execution
 #[derive(Debug)]
-pub(crate) struct KernelInfo {
+pub(crate) struct KernelInfo<MemLayout: MemoryLayout> {
 	/// The first instruction after boot
 	pub entry_point: GuestPhysAddr,
+	pub layout: MemLayout,
 	/// The starting position of the image in physical memory
 	// currently only needed in gdb
-	pub kernel_address: GuestPhysAddr,
 	pub params: Params,
 	pub path: PathBuf,
-	pub stack_address: GuestPhysAddr,
-	/// The location of the whole guest in the physical address space
-	pub guest_address: GuestPhysAddr,
 }
 
-// guest_address + OFFSET
-pub(crate) const BOOT_INFO_OFFSET: u64 = 0x9000;
-const FDT_OFFSET: u64 = 0x5000;
-pub(crate) const KERNEL_OFFSET: u64 = 0x40000;
-const KERNEL_STACK_SIZE: u64 = 0x8000;
 /// The signal for kicking vCPUs out of KVM_RUN.
 ///
 /// It is used to stop a vCPU from another thread.
 pub(crate) struct KickSignal;
 
-/// Returns a guest & start address tuple based on the object file.
-///
-/// Generates a tuple containing a potentially random guest address and a derived
-/// start address for Uhyve's virtualized memory. The guest address will not be
-/// random under the following conditions:
-/// - The image is not relocatable / uses uhyve-interface v1.
-/// - ASLR is disabled.
-///
-/// If the image is not relocatable, the start address will be equal to that
-/// present in the unikernel image file's object representation.
-///
-/// - `interface_version`: Version of uhyve-interface.
-/// - `aslr`: `bool` describing whether ASLR is enabled (`true`) or disabled (`false`).
-/// - `object_mem_size`: Memory required to load the object file onto the guest's memory.
-/// - `object_start_addr`: Start address embedded in the unikernel image (if applicable).
-/// - `mem_size`: User-defined memory size that should be available to the VM.
-pub(crate) fn generate_guest_start_address(
-	interface_version: UhyveIfVersion,
-	aslr: bool,
-	object_mem_size: usize,
-	object_start_addr: Option<u64>,
-	mem_size: usize,
-) -> (GuestPhysAddr, GuestPhysAddr) {
-	// Using an interface-specific version's range and by using checked_sub, we
-	// guarantee that the range used during the kernel's execution won't lead
-	// to a boundary violation during the guest's execution.
-	let (guest_address_lb, guest_address_ub): (u64, u64) = {
-		let range = match interface_version.0 {
-			1 => V1_ADDR_RANGE,
-			2 | 3 => V2_ADDR_RANGE,
-			_ => unimplemented!(),
-		};
-		// KERNEL_OFFSET will be added again later for the start address, later.
-		let mem_size = (object_mem_size + mem_size) as u64 + KERNEL_OFFSET;
-		(
-			range.0,
-			range.1.checked_sub(mem_size).unwrap_or_else(|| {
-				let (lb, ub) = range;
-				let hint = match interface_version.0 {
-					1 => " (More than 3GiB memory is not supported for Hermit <= 0.13.2)",
-					2 | 3 => "",
-					_ => unimplemented!(),
-				};
-				panic!("Out of range [{lb:#x}, {ub:#x}) due to memory size {mem_size:#x}.{hint}")
-			}),
-		)
-	};
-
-	match (aslr, object_start_addr) {
-		(true, None) => {
-			let mut rng = rand::rng();
-			let guest_address = GuestPhysAddr::new(
-				rand::RngExt::random_range(&mut rng, guest_address_lb..=guest_address_ub)
-					.align_down(0x20_0000),
-			);
-			(guest_address, guest_address.add(KERNEL_OFFSET))
-		}
-		(false, None) => {
-			let guest_address = GuestPhysAddr::new(guest_address_lb);
-			(guest_address, guest_address.add(KERNEL_OFFSET))
-		}
-		(_, Some(predefined_start_address)) => {
-			assert!(
-				(guest_address_lb..=guest_address_ub).contains(&predefined_start_address),
-				"Predefined address {predefined_start_address:#x} out of range of possible
-				 guest addresses: [{guest_address_lb:#x}, {guest_address_ub:#x}]."
-			);
-			if aslr {
-				warn!("ASLR is enabled but kernel is not relocatable - disabling ASLR");
-			}
-			(
-				GuestPhysAddr::new(guest_address_lb),
-				GuestPhysAddr::new(predefined_start_address),
-			)
-		}
-	}
-}
-
 pub struct UhyveVm<VirtBackend: VirtualizationBackend> {
 	pub(crate) vcpus: Vec<<VirtBackend as VirtualizationBackendInternal>::VCPU>,
 	pub(crate) peripherals: Arc<VmPeripherals<VirtBackend::VirtioNetImpl>>,
-	pub(crate) kernel_info: Arc<KernelInfo>,
+	pub(crate) kernel_info: Arc<KernelInfo<VirtBackend::MemLayout>>,
 	_virt_backend: VirtBackend,
 }
 #[allow(private_bounds)]
@@ -391,50 +317,14 @@ impl<VirtBackend: VirtualizationBackend<VirtioNetImpl: NetworkBackend>> UhyveVm<
 			.uhyve_interface_version()
 			.unwrap_or(UhyveIfVersion(1));
 
-		// The memory layout of uhyve looks as follows:
-		//
-		//     0x0000_0000 ┌───────────────────┐
-		//                 │ Hypercalls        │
-		//                 ├───────────────────┤
-		//                 │ not present       │
-		//                 │                   │
-		//    guest_address├───────────────────┤ ▲ ▲ ▲ ▲
-		//                 │                   │ │ │ │ │BOOT_INFO_OFFSET
-		//                 ├───────────────────┤ │ │ │ ▼
-		//                 │ Boot Info         │ │ │ │FDT_OFFSET
-		//                 ├───────────────────┤ │ │ ▼
-		//                 │ Device Tree (FDT) │ │ │
-		//                 ├───────────────────┤ │ │
-		//                 │                   │ │ │PAGETABLE_OFFSET
-		//                 ├───────────────────┤ │ ▼
-		//                 │ Pagetables        │ │
-		//    stack_address├───────────────────┤ │
-		//                 │ Stack             │ │KERNEL_OFFSET
-		//   kernel_address├───────────────────┤ ▼
-		//                 │ Kernel            │
-		//   entry_point──►│                   │
-		//                 │                   │
-		//                 ├───────────────────┤
-		//                 │ Kernel Memory     │
-		//                 │                   │
-		//                 └───────────────────┘
-
-		let (guest_address, kernel_address) = generate_guest_start_address(
-			uhyve_interface_version,
-			params.aslr,
-			object.mem_size(),
-			object.start_addr(),
-			memory_size,
-		);
-
-		debug!("Guest starts at {guest_address:#x}");
-		debug!("Kernel gets loaded to {kernel_address:#x}");
+		let layout = VirtBackend::MemLayout::new(&params, &object);
+		debug!("{layout}");
 
 		#[cfg(target_os = "linux")]
-		let mut mem = MmapMemory::new(memory_size, guest_address, params.thp, params.ksm);
+		let mut mem = MmapMemory::new(memory_size, layout.guest_address(), params.thp, params.ksm);
 
 		#[cfg(not(target_os = "linux"))]
-		let mut mem = MmapMemory::new(memory_size, guest_address, false, false);
+		let mut mem = MmapMemory::new(memory_size, layout.guest_address(), false, false);
 
 		let mounts: Vec<_> = file_mapping.get_all_guest_dirs().collect();
 
@@ -451,40 +341,58 @@ impl<VirtBackend: VirtualizationBackend<VirtioNetImpl: NetworkBackend>> UhyveVm<
 			&params.trace_dir,
 		);
 
-		assert!(
-			kernel_address.as_u64() > KERNEL_STACK_SIZE,
-			"there should be enough space for the boot stack before the kernel start address",
-		);
-		let stack_address = kernel_address - KERNEL_STACK_SIZE;
-		debug!("Stack starts at {stack_address:#x}");
-
 		let (
 			LoadedKernel {
 				load_info,
 				entry_point,
 			},
 			kernel_end_address,
-		) = load_kernel_to_mem(&object, &mut mem, kernel_address - guest_address)
-			.expect("Unable to load Kernel {kernel_path}");
+		) = load_kernel_to_mem(
+			&object,
+			&mut mem,
+			layout.kernel_address() - layout.guest_address(),
+		)
+		.expect("Unable to load Kernel {kernel_path}");
 
 		// Allocate memory for hermit image
 		let hermit_image = hermit_image.map(|hermit_image| {
 			load_hermit_image_to_mem(
 				&hermit_image[..],
 				&mut mem,
-				(kernel_end_address - guest_address).align_up(PAGE_SIZE as u64),
+				(kernel_end_address - layout.guest_address()).align_up(PAGE_SIZE as u64),
 			)
 			.expect("Unable to load Hermit image {kernel_path}")
 		});
 
 		let kernel_info = Arc::new(KernelInfo {
 			entry_point: entry_point.into(),
-			kernel_address,
-			guest_address: mem.guest_addr(),
+			layout,
 			path: kernel_path,
 			params,
-			stack_address,
 		});
+
+		let legacy_mapping = if let Some(version) = hermit_version {
+			// actually, all versions that have the tag in the elf are valid, but an explicit check doesn't hurt
+			version
+				< HermitVersion {
+					major: 0,
+					minor: 10,
+					patch: 0,
+				}
+		} else {
+			true
+		};
+		trace!("Initialize guest memory");
+		VirtBackend::init_guest_mem(
+			&mut mem,
+			&layout,
+			hermit_image
+				.clone()
+				.map(|i| i.end)
+				.unwrap_or(kernel_end_address)
+				- layout.guest_address(),
+			legacy_mapping,
+		);
 
 		// create virtio interface
 		let mem = Arc::new(mem);
@@ -542,36 +450,22 @@ impl<VirtBackend: VirtualizationBackend<VirtioNetImpl: NetworkBackend>> UhyveVm<
 
 		write_fdt_into_mem(
 			&peripherals.mem,
+			layout.fdt(),
 			&kernel_info.params,
-			hermit_image.clone(),
+			hermit_image,
 			freq,
 			mounts,
 		);
 		write_boot_info_to_mem(
 			&peripherals.mem,
+			layout.boot_info(),
+			layout.fdt().0.addr,
 			load_info,
 			cpu_count as u64,
 			freq,
 			serial_port,
 		);
 
-		let legacy_mapping = if let Some(version) = hermit_version {
-			// actually, all versions that have the tag in the elf are valid, but an explicit check doesn't hurt
-			version
-				< HermitVersion {
-					major: 0,
-					minor: 10,
-					patch: 0,
-				}
-		} else {
-			true
-		};
-		init_guest_mem(
-			unsafe { peripherals.mem.as_slice_mut() }, // slice only lives during this fn call
-			guest_address,
-			hermit_image.map(|i| i.end).unwrap_or(kernel_end_address) - guest_address,
-			legacy_mapping,
-		);
 		trace!("VM initialization complete");
 
 		Ok(Self {
@@ -736,8 +630,7 @@ impl<VirtIf: VirtualizationBackend + Debug> fmt::Debug for UhyveVm<VirtIf> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		f.debug_struct(&format!("UhyveVm<{}>", VirtIf::NAME))
 			.field("entry_point", &self.kernel_info.entry_point)
-			.field("stack_address", &self.kernel_info.stack_address)
-			.field("guest_address", &self.kernel_info.guest_address)
+			.field("layout", &self.kernel_info.layout)
 			.field("mem", &self.peripherals.mem)
 			.field("path", &self.kernel_info.path)
 			.field("virtio_device", &self.peripherals.virtio_device)
@@ -747,21 +640,9 @@ impl<VirtIf: VirtualizationBackend + Debug> fmt::Debug for UhyveVm<VirtIf> {
 	}
 }
 
-/// Initialize the page tables for the guest
-/// `memory_size` is the length of the memory from the start of the physical
-/// memory till the end of the kernel in bytes.
-fn init_guest_mem(
-	mem: &mut [u8],
-	guest_addr: GuestPhysAddr,
-	memory_size: u64,
-	legacy_mapping: bool,
-) {
-	trace!("Initialize guest memory");
-	crate::arch::init_guest_mem(mem, guest_addr, memory_size, legacy_mapping);
-}
-
 fn write_fdt_into_mem(
 	mem: &MmapMemory,
+	fdt_section: FdtSection,
 	params: &Params,
 	hermit_image: Option<core::ops::Range<GuestPhysAddr>>,
 	cpu_freq: Option<NonZero<u32>>,
@@ -804,30 +685,27 @@ fn write_fdt_into_mem(
 	let fdt = fdt.finish().unwrap();
 
 	debug!("fdt.len() = {}", fdt.len());
-	assert!(fdt.len() < (BOOT_INFO_OFFSET - FDT_OFFSET) as usize);
-	unsafe {
-		let fdt_ptr = mem.host_start().add(FDT_OFFSET as usize);
-		fdt_ptr.copy_from_nonoverlapping(fdt.as_ptr(), fdt.len());
-	}
+	assert!(fdt.len() < fdt_section.0.length);
+	let fdt_target = unsafe { mem.slice_at_mut(fdt_section.0.addr, fdt.len()).unwrap() };
+	fdt_target.copy_from_slice(&fdt);
 }
 
 fn write_boot_info_to_mem(
 	mem: &MmapMemory,
+	boot_info_section: BootInfoSection,
+	fdt_addr: GuestPhysAddr,
 	load_info: LoadInfo,
 	num_cpus: u64,
 	cpu_freq: Option<NonZero<u32>>,
 	#[cfg(target_arch = "x86_64")] serial_port: Option<NonZero<u16>>,
 	#[cfg(target_arch = "aarch64")] serial_port: Option<NonZero<u64>>,
 ) {
-	debug!(
-		"Writing BootInfo to {:?}",
-		mem.guest_addr() + BOOT_INFO_OFFSET
-	);
+	debug!("Writing BootInfo to {:?}", boot_info_section.0.addr,);
 	let boot_info = BootInfo {
 		hardware_info: HardwareInfo {
 			phys_addr_range: mem.address_range_u64(),
 			serial_port_base: serial_port,
-			device_tree: Some((mem.guest_addr().as_u64() + FDT_OFFSET).try_into().unwrap()),
+			device_tree: Some(fdt_addr.as_u64().try_into().unwrap()),
 		},
 		load_info,
 		platform_info: PlatformInfo::Uhyve {
@@ -837,10 +715,8 @@ fn write_boot_info_to_mem(
 			boot_time: SystemTime::now().into(),
 		},
 	};
-	unsafe {
-		let raw_boot_info_ptr = mem.host_start().add(BOOT_INFO_OFFSET as usize) as *mut RawBootInfo;
-		*raw_boot_info_ptr = RawBootInfo::from(boot_info);
-	}
+	assert!(boot_info_section.0.length >= size_of::<RawBootInfo>());
+	*unsafe { mem.get_ref_mut(boot_info_section.0.addr) }.unwrap() = RawBootInfo::from(boot_info);
 }
 
 /// loads the kernel `object` into `mem`. `relative_offset` is the start address the kernel relative to `mem`.
@@ -911,112 +787,4 @@ fn load_hermit_image_to_mem(
 	}
 
 	Some(image_start_address..image_end_address)
-}
-
-#[cfg(test)]
-mod tests {
-	use std::ops::Add;
-
-	use hermit_entry::UhyveIfVersion;
-
-	use crate::{
-		RAM_START, V1_MAX_ADDR,
-		vm::{KERNEL_OFFSET, generate_guest_start_address},
-	};
-
-	#[test]
-	fn test_generate_guest_start_address() {
-		let mem_size: usize = 0xBE20_0000; // 3042 MiB
-		let if_v1 = UhyveIfVersion(1);
-		let if_v2 = UhyveIfVersion(2);
-		let object_mem_size: usize = 0x0009_C400;
-		let object_no_start_addr: Option<u64> = None;
-		#[cfg(target_arch = "x86_64")]
-		let object_start_addr: u64 = 0x0002_0000;
-		#[cfg(target_arch = "aarch64")]
-		let object_start_addr: u64 = 0x1002_0000;
-
-		/* v1 */
-
-		// v1: No ASLR, relocatable
-		let (mut guest_address, mut start_address) = generate_guest_start_address(
-			if_v1,
-			false,
-			object_mem_size,
-			object_no_start_addr,
-			mem_size,
-		);
-		assert_eq!(guest_address, RAM_START);
-		assert_eq!(start_address, guest_address.add(KERNEL_OFFSET));
-
-		// v1: ASLR, relocatable
-		(guest_address, start_address) = generate_guest_start_address(
-			if_v1,
-			true,
-			object_mem_size,
-			object_no_start_addr,
-			mem_size,
-		);
-		assert_eq!(start_address, guest_address.add(KERNEL_OFFSET));
-		assert!(start_address.as_u64() <= V1_MAX_ADDR);
-
-		// v1: ASLR, non-relocatable
-		(guest_address, start_address) = generate_guest_start_address(
-			if_v1,
-			true,
-			object_mem_size,
-			object_start_addr.into(),
-			mem_size,
-		);
-		assert_eq!(guest_address, RAM_START);
-		assert_eq!(start_address.as_u64(), object_start_addr);
-		// Note that this is a bit brittle and implicitly relies on RAM_START.
-		assert_eq!(start_address, guest_address.add(0x0002_0000usize));
-		assert!(start_address.as_u64() <= V1_MAX_ADDR);
-
-		/* v2 */
-
-		// v2: No ASLR, relocatable
-		(guest_address, start_address) = generate_guest_start_address(
-			if_v2,
-			false,
-			object_mem_size,
-			object_no_start_addr,
-			mem_size,
-		);
-		assert_eq!(guest_address.as_u64(), 0x0001_0000_0000u64);
-		assert_eq!(start_address, guest_address.add(KERNEL_OFFSET));
-		#[cfg(target_arch = "x86_64")]
-		assert!(start_address.as_u64() >= V1_MAX_ADDR);
-
-		// v2: ASLR, relocatable
-		(guest_address, start_address) = generate_guest_start_address(
-			if_v2,
-			true,
-			object_mem_size,
-			object_no_start_addr,
-			mem_size,
-		);
-		assert_eq!(start_address, guest_address.add(KERNEL_OFFSET));
-		#[cfg(target_arch = "x86_64")]
-		assert!(start_address.as_u64() >= V1_MAX_ADDR);
-
-		// v2: Use entire memory available
-		//
-		// (This effectively renders ASLR worthless, yet it is great for testing,
-		//  underlying arithmetic operations for potential regressions without
-		//  exclusively relying on randomness!)
-		(guest_address, start_address) = generate_guest_start_address(
-			if_v2,
-			true,
-			object_mem_size,
-			object_no_start_addr,
-			// Highest address, minus everything that is subtracted from it in the function.
-			0x0010_0000_0000 - object_mem_size - KERNEL_OFFSET as usize - 0x0001_0000_0000,
-		);
-		assert_eq!(guest_address.as_u64(), 0x0001_0000_0000);
-		assert_eq!(start_address, guest_address.add(KERNEL_OFFSET));
-		#[cfg(target_arch = "x86_64")]
-		assert!(start_address.as_u64() >= V1_MAX_ADDR);
-	}
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -32,7 +32,7 @@ use crate::{
 	gdb::GdbVcpuManager,
 	isolation::filemap::{UhyveFileMap, UhyveMapLeaf},
 	mem::MmapMemory,
-	mem_layout::{BootInfoSection, FdtSection, MemoryLayout},
+	mem_layout::{BootInfoSection, FdtSection, KernelSection, MemoryLayout},
 	net::NetworkBackend,
 	params::{EnvVars, HermitImageMode, NetworkMode, Params},
 	parking::Parker,
@@ -347,12 +347,8 @@ impl<VirtBackend: VirtualizationBackend<VirtioNetImpl: NetworkBackend>> UhyveVm<
 				entry_point,
 			},
 			kernel_end_address,
-		) = load_kernel_to_mem(
-			&object,
-			&mut mem,
-			layout.kernel_address() - layout.guest_address(),
-		)
-		.expect("Unable to load Kernel {kernel_path}");
+		) = load_kernel_to_mem(&object, &mut mem, &layout.kernel())
+			.expect("Unable to load Kernel {kernel_path}");
 
 		// Allocate memory for hermit image
 		let hermit_image = hermit_image.map(|hermit_image| {
@@ -686,7 +682,7 @@ fn write_fdt_into_mem(
 
 	debug!("fdt.len() = {}", fdt.len());
 	assert!(fdt.len() < fdt_section.0.length);
-	let fdt_target = unsafe { mem.slice_at_mut(fdt_section.0.addr, fdt.len()).unwrap() };
+	let fdt_target = unsafe { &mut mem.section_slice_mut(fdt_section.0).unwrap()[0..fdt.len()] };
 	fdt_target.copy_from_slice(&fdt);
 }
 
@@ -724,9 +720,9 @@ fn write_boot_info_to_mem(
 fn load_kernel_to_mem(
 	object: &KernelObject<'_>,
 	mem: &mut MmapMemory,
-	relative_offset: u64,
+	kernel_section: &KernelSection,
 ) -> LoadKernelResult<(LoadedKernel, GuestPhysAddr)> {
-	let kernel_end_address = mem.guest_addr() + relative_offset + object.mem_size();
+	let kernel_end_address = kernel_section.0.end();
 
 	if kernel_end_address > mem.guest_addr() + mem.size() {
 		return Err(LoadKernelError::InsufficientMemory);
@@ -734,10 +730,9 @@ fn load_kernel_to_mem(
 
 	Ok((
 		object.load_kernel(
-			// Safety: Slice only lives during this fn call, so no aliasing happens
-			&mut unsafe { mem.as_slice_uninit_mut() }
-				[relative_offset as usize..relative_offset as usize + object.mem_size()],
-			relative_offset + mem.guest_addr().as_u64(),
+			// Safety: Slice only lives during this fn call, so no aliasing happens.
+			unsafe { mem.section_slice_mut(kernel_section.0).unwrap() },
+			kernel_section.0.addr.as_u64(),
 		),
 		kernel_end_address,
 	))

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -368,7 +368,7 @@ impl<VirtBackend: VirtualizationBackend<VirtioNetImpl: NetworkBackend>> UhyveVm<
 		});
 
 		let legacy_mapping = if let Some(version) = hermit_version {
-			// actually, all versions that have the tag in the elf are valid, but an explicit check doesn't hurt
+			// actually, all versions that have the tag in the elf don't use legacy mapping, but an explicit check doesn't hurt
 			version
 				< HermitVersion {
 					major: 0,


### PR DESCRIPTION
The impls. of `MemoryLayout` (`Aarch64MemoryLayout` and `X86_64MemoryLayout`) are basically duplicates, but semantically this makes more sense and also gives us more freedom to modify the layout for architecture-specific features.

Closes #1303 