### PR TITLE
feat(initramfs): Don't align the hermit image / initramfs length to `PAGE_SIZE`

### DIFF
--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -2,6 +2,7 @@
 
 use core::{fmt::Write, ops::Range};
 
+use align_address::Align as _;
 use uhyve_interface::GuestPhysAddr;
 use vm_fdt::{FdtWriter, FdtWriterNode, FdtWriterResult};
 
@@ -32,8 +33,10 @@ impl Fdt {
 			let start = hermit_image.start.as_u64();
 			let end = hermit_image.end.as_u64();
 			let length = end.checked_sub(start).unwrap();
-			assert_eq!(length % PAGE_SIZE as u64, 0);
-			mem_reserved.push(vm_fdt::FdtReserveEntry::new(start, length)?);
+			mem_reserved.push(vm_fdt::FdtReserveEntry::new(
+				start,
+				length.align_up(PAGE_SIZE as u64),
+			)?);
 			Some(start..end)
 		} else {
 			None

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -749,6 +749,7 @@ fn load_hermit_image_to_mem(
 
 	let aligned_image_len = hermit_image.len().align_up(PAGE_SIZE);
 	let image_start_address = mem.guest_addr() + relative_offset;
+	let image_actual_end_address = image_start_address + hermit_image.len() as u64;
 	let image_end_address = image_start_address + aligned_image_len as u64;
 
 	if image_end_address > mem.guest_addr() + mem.size() {
@@ -781,5 +782,5 @@ fn load_hermit_image_to_mem(
 		warn!("Hermit image mprotect(2) failed: {e}");
 	}
 
-	Some(image_start_address..image_end_address)
+	Some(image_start_address..image_actual_end_address)
 }


### PR DESCRIPTION
Note that we still have to do that for the reserved memory region.