### PR TITLE
fix(hypercall): Fix missing offset update on read of virtual FDs

### DIFF
--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -546,6 +546,7 @@ fn read(mem: &MmapMemory, sysread: &mut v2::parameters::ReadParams, file_map: &m
 							amt,
 						)
 					};
+					*offset += amt as u64;
 					amt as i64
 				}
 				FdData::MappedDirectory { .. } => -EBADF as i64,


### PR DESCRIPTION
This bug was found by the hanging `initramfs-test` in `hermit-rs` when using `--hermit-image-mode external`.