### PR TITLE
Fix the mkdir hypercall

### DIFF
--- a/src/hypercall/by_path.rs
+++ b/src/hypercall/by_path.rs
@@ -197,43 +197,47 @@ pub(super) fn open(mem: &MmapMemory, sysopen: &mut OpenParams, file_map: &mut Uh
 	}
 }
 
-/// Attempts `mkdir(host_path)` on the host, mapping the outcome to a [`MkdirResult`].
-fn host_mkdir(host_path_c: &CString) -> MkdirResult {
-	// SAFETY: `host_path_c` is a valid, null-terminated C string.
-	if unsafe { libc::mkdir(host_path_c.as_ptr(), 0o777) } < 0 {
-		MkdirResult::Error(translate_last_errno().unwrap_or(EIO))
-	} else {
-		MkdirResult::Success
-	}
-}
-
 /// Handles a mkdir hypercall by creating a directory on the host.
 ///
 /// The guest path is resolved through the file map, so directories can only be created
 /// within mapped host directories. Unmapped paths are redirected into the sandboxed
 /// temporary directory. Virtual paths are rejected.
 pub(super) fn mkdir(mem: &MmapMemory, sysmkdir: &mut MkdirParams, file_map: &mut UhyveFileMap) {
-	let Some(guest_path) = (unsafe { decode_guest_path(mem, sysmkdir.path) }) else {
-		error!("The kernel requested to mkdir() a non-UTF8 path: Rejecting...");
-		sysmkdir.ret = MkdirResult::Error(EINVAL);
-		return;
+	let host_path_c_res = match unsafe { decode_guest_path(mem, sysmkdir.name) } {
+		None => {
+			error!("The kernel requested to mkdir() a non-UTF8 path: Rejecting...");
+			Err(EINVAL)
+		}
+		Some(guest_path) => {
+			match file_map.get_host_path(guest_path, false) {
+				Some(UhyveMapLeaf::OnHost(host_path)) => {
+					// We can safely unwrap, as a resolved host path never contains internal NUL bytes.
+					Ok(CString::new(host_path.as_os_str().as_bytes()).unwrap())
+				}
+				Some(UhyveMapLeaf::Virtual(_)) => {
+					debug!(
+						"mkdir {guest_path:?}: target is a read-only virtual file, rejecting..."
+					);
+					Err(EROFS)
+				}
+				None => {
+					debug!("mkdir {guest_path:?}: not mapped, creating a temporary directory...");
+					file_map
+						.create_temporary_directory(guest_path)
+						.ok_or(EINVAL)
+				}
+			}
+		}
 	};
 
-	sysmkdir.ret = match file_map.get_host_path(guest_path, false) {
-		Some(UhyveMapLeaf::OnHost(host_path)) => {
-			// We can safely unwrap, as a resolved host path never contains internal NUL bytes.
-			let host_path_c = CString::new(host_path.as_os_str().as_bytes()).unwrap();
-			host_mkdir(&host_path_c)
-		}
-		Some(UhyveMapLeaf::Virtual(_)) => {
-			debug!("mkdir {guest_path:?}: target is a read-only virtual file, rejecting...");
-			MkdirResult::Error(EROFS)
-		}
-		None => {
-			debug!("mkdir {guest_path:?}: not mapped, creating a temporary directory...");
-			match file_map.create_temporary_directory(guest_path) {
-				Some(host_path_c) => host_mkdir(&host_path_c),
-				None => MkdirResult::Error(EINVAL),
+	sysmkdir.ret = match host_path_c_res {
+		Err(errno) => -errno,
+		// Attempts `mkdir(host_path)` on the host, mapping the outcome to guest errno value fit for [`MkdirParams::ret`].
+		Ok(host_path_c) => {
+			if unsafe { libc::mkdir(host_path_c.as_ptr(), sysmkdir.mode.into()) } < 0 {
+				-translate_last_errno().unwrap_or(EIO)
+			} else {
+				0
 			}
 		}
 	};

--- a/tests/test-kernels/src/bin/fs_tests.rs
+++ b/tests/test-kernels/src/bin/fs_tests.rs
@@ -15,8 +15,7 @@ use uhyve_interface::{
 		Hypercall,
 		parameters::{
 			Dirent64, FileAttr, FileType, FstatParams, GetdentParams, GetdentResult, MkdirParams,
-			MkdirResult, O_DIRECTORY, O_RDONLY, OpenParams, StatKind, StatParams, StatResult,
-			Timespec,
+			O_DIRECTORY, O_RDONLY, OpenParams, StatKind, StatParams, StatResult, Timespec,
 		},
 	},
 };
@@ -279,13 +278,13 @@ fn hypercall_mkdir(dirname: &str) {
 	let path = CString::new(dirname).unwrap();
 	let path_phys = virtual_to_physical(GuestVirtAddr::from_ptr(path.as_ptr())).unwrap();
 	let mut mkdir_params = MkdirParams {
-		path: path_phys,
-		len: dirname.len() as u64 + 1,
-		ret: MkdirResult::None,
+		name: path_phys,
+		mode: 0o777,
+		ret: 0,
 	};
 	uhyve_hypercall(Hypercall::Mkdir(&mut mkdir_params));
 
-	let MkdirResult::Success = mkdir_params.ret else {
+	if mkdir_params.ret != 0 {
 		panic!("Mkdir hypercall not successful: {:?}", mkdir_params.ret);
 	};
 

--- a/uhyve-interface/src/v2/parameters.rs
+++ b/uhyve-interface/src/v2/parameters.rs
@@ -126,28 +126,16 @@ pub struct GetdentParams {
 	pub ret: GetdentResult,
 }
 
-/// Result of a [`Mkdir`](crate::v2::Hypercall::Mkdir) hypercall.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub enum MkdirResult {
-	/// No result. Guests should set this value before calling the hypercall.
-	None,
-	/// Directory was created.
-	Success,
-	/// Error with libc errno.
-	Error(i32),
-}
-
 /// Parameters for a [`Mkdir`](crate::v2::Hypercall::Mkdir) hypercall.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MkdirParams {
 	/// Path to create. Zero terminated C-String.
-	pub path: GuestPhysAddr,
-	/// Length of the path buffer.
-	pub len: u64,
-	/// Return value of the hypercall.
-	pub ret: MkdirResult,
+	pub name: GuestPhysAddr,
+	/// Return value of the hypercall, `0` on success and `-errno` on failure.
+	pub ret: i32,
+	/// Access permissions upon creating the directory.
+	pub mode: u16,
 }
 
 /// Which stat-like operation to perform.


### PR DESCRIPTION
I tried to integrate the `mkdir` hypercall into the Hermit kernel and noticed that it is
* unstable/experimental: because the hermit kernel doesn't have any hooks that use it, yet, meaning we can still modify it in `uhyve-interface` without breaking any real-world relied-upon stable hypercall API; In particular, the only accessed part on the Hermit side is the big `enum Hypercall`, which only contains pointers (and thus whose size won't change with this modification),
* contains redundant parameters (`len`),
* doesn't contain usually necessary parameters (`mode`), required by analogy to `open`, and what is usually expected from the `hermit-kernel` VFS interface.

Therefore, this PR fixes those oversights.
Afterwards, it restructures the distribution of methods across the files in the `uhyve/src/hypercall` folder for increased future maintainability (and to avoid conflicts that would immediately occur if one would split this PR into two at that point).

Given that we likely need another release of `uhyve` soon, this PR has some increased priority to be integrated before the associated version freeze.

Depends on #1480.