### PR TITLE
feat(uhyve-interface/v2): add a FileFsync hypercall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "uhyve-interface"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aarch64",
  "hermit-abi",

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -116,6 +116,7 @@ pub unsafe fn address_to_hypercall_v2(
 		HypercallAddress::FileStat => Hypercall::FileStat(get_data!()),
 		HypercallAddress::FileFstat => Hypercall::FileFstat(get_data!()),
 		HypercallAddress::Mkdir => Hypercall::Mkdir(get_data!()),
+		HypercallAddress::FileFsync => Hypercall::FileFsync(get_data!()),
 		_ => return None,
 	})
 }
@@ -154,6 +155,7 @@ pub fn handle_hypercall_v2<N: NetworkBackend>(
 		v2::Hypercall::FileStat(sysstat) => stat(&peripherals.mem, sysstat, &file_mapping()),
 		v2::Hypercall::FileFstat(sysfstat) => fstat(&peripherals.mem, sysfstat, &file_mapping()),
 		v2::Hypercall::Mkdir(sysmkdir) => mkdir(&peripherals.mem, sysmkdir, &mut file_mapping()),
+		v2::Hypercall::FileFsync(sysfsync) => fsync(sysfsync, &file_mapping()),
 		v2::Hypercall::SerialWriteByte(buf) => peripherals
 			.serial
 			.output(&[buf])
@@ -803,4 +805,25 @@ fn copy_env(env: &EnvVars, syscmdval: &v1::parameters::CmdvalParams, mem: &MmapM
 		env_dest[key.len() + 1..len].copy_from_slice(value.as_bytes());
 		env_dest[len] = 0;
 	}
+}
+
+/// Handler for a [`FileFsync`](v2::Hypercall::FileFsync) hypercall.
+fn fsync(sysfsync: &mut FsyncParams, file_map: &UhyveFileMap) {
+	let Some(fddata) = file_map.fdmap.get(GuestFd(sysfsync.fd)) else {
+		sysfsync.ret = -EBADF;
+		return;
+	};
+
+	let FdData::Raw(host_fd) = fddata else {
+		sysfsync.ret = 0;
+		return;
+	};
+
+	let result = unsafe { libc::fsync(*host_fd) };
+
+	sysfsync.ret = if result < 0 {
+		-translate_last_errno().unwrap_or(1)
+	} else {
+		0
+	};
 }

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhyve-interface"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["The Hermit Project Developers"]
 description = "The interface between uhyve and a guest VM"

--- a/uhyve-interface/src/v2/mod.rs
+++ b/uhyve-interface/src/v2/mod.rs
@@ -31,6 +31,7 @@ pub enum HypercallAddress {
 	FileStat = 0x1170,
 	FileFstat = 0x1180,
 	Mkdir = 0x1190,
+	FileFsync = 0x11A0,
 	SharedMemOpen = 0x1200,
 	SharedMemClose = 0x1210,
 }
@@ -45,6 +46,7 @@ into_hypercall_addresses! {
 			FileRead,
 			FileUnlink,
 			FileWrite,
+			FileFsync,
 			Getdents,
 			Mkdir,
 			FileStat,
@@ -77,6 +79,8 @@ pub enum Hypercall<'a> {
 	FileFstat(&'a mut FstatParams),
 	/// Create a new directory.
 	Mkdir(&'a mut MkdirParams),
+	/// Flush a file to the storage it lives on.
+	FileFsync(&'a mut FsyncParams),
 	/// Write a char to the terminal.
 	SerialWriteByte(u8),
 	/// Write a buffer to the terminal

--- a/uhyve-interface/src/v2/parameters.rs
+++ b/uhyve-interface/src/v2/parameters.rs
@@ -237,3 +237,16 @@ pub struct FstatParams {
 	/// Return value of the hypercall.
 	pub ret: StatResult,
 }
+
+/// Parameters for a [`FileFsync`](crate::v2::Hypercall::FileFsync) hypercall.
+///
+/// Guest writes end up in the host's page cache, so this is the only place a
+/// flush means anything: it is the host that owns the file.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FsyncParams {
+	/// Guest file descriptor (from [`FileOpen`](crate::v2::Hypercall::FileOpen)).
+	pub fd: i32,
+	/// `0` on success, otherwise a negative errno.
+	pub ret: i32,
+}


### PR DESCRIPTION
Guest writes land in the host's page cache, so a flush only means something on the host side, where the file lives.

The handler maps the fd through UhyveFileMap and calls libc::fsync. Anything that is not a raw host fd reports success, since there is nothing to flush.