### PR TITLE
chore(uhyvelib): Outlaw unreachable patterns by default

### DIFF
--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -693,7 +693,7 @@ fn lseek(syslseek: &mut LseekParams, file_map: &mut UhyveFileMap) {
 			}
 		}
 		Some(FdData::Virtual { data, offset }) => {
-			#[forbid(unused_variables, unreachable_patterns)]
+			#[forbid(unused_variables)]
 			let tmp: i64 = match syslseek.whence as i32 {
 				SEEK_SET => 0,
 				SEEK_CUR => *offset as i64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![warn(rust_2018_idioms)]
 #![allow(clippy::useless_conversion)]
+#![deny(unreachable_patterns)]
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
They're almost always an error anyways, and should be treated as anywhere.