### PR TITLE
Uhyve interface: Add serde support & snapshot hypercall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,7 @@ checksum = "a33ce19da78c437cf69f8c3265a77ca61e08395678b7b9eac42039add3f4f4fb"
 dependencies = [
  "align-address 0.4.0",
  "cfg-if",
+ "serde",
  "x86",
  "x86_64",
 ]
@@ -1825,6 +1826,7 @@ dependencies = [
  "log",
  "memory_addresses 0.4.0",
  "num_enum",
+ "serde",
  "x86_64",
 ]
 

--- a/uhyve-interface/Cargo.toml
+++ b/uhyve-interface/Cargo.toml
@@ -14,9 +14,12 @@ hermit-abi = "0.5"
 log = { version = "0.4", optional = true }
 memory_addresses = "0.4"
 num_enum = { version = "0.7", default-features = false }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 [features]
+default = []
 std = ["dep:log"]
+serde = ["dep:serde", "memory_addresses/serde"]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.15", default-features = false }

--- a/uhyve-interface/src/v1/mod.rs
+++ b/uhyve-interface/src/v1/mod.rs
@@ -11,6 +11,8 @@
 
 pub mod parameters;
 use parameters::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Enum containing all valid port mappings for hypercalls.
 ///
@@ -19,6 +21,7 @@ use parameters::*;
 #[repr(u16)]
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, num_enum::TryFromPrimitive, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HypercallAddress {
 	/// Port address = `0x400`
 	FileWrite = 0x400,

--- a/uhyve-interface/src/v2/mod.rs
+++ b/uhyve-interface/src/v2/mod.rs
@@ -37,6 +37,7 @@ pub enum HypercallAddress {
 	Mkdir = 0x1190,
 	SharedMemOpen = 0x1200,
 	SharedMemClose = 0x1210,
+	Snapshot = 0x1400,
 }
 
 into_hypercall_addresses! {
@@ -57,6 +58,7 @@ into_hypercall_addresses! {
 			SerialReadByte,
 			SerialWriteBuffer,
 			SerialWriteByte,
+			Snapshot
 		}
 	}
 }
@@ -89,6 +91,10 @@ pub enum Hypercall<'a> {
 	SerialReadByte,
 	/// Read a buffer from the terminal
 	SerialReadBuffer(&'a SerialReadBufferParams),
+	/// Take a snapshot of the VM.
+	///
+	/// This is only allowed, once the Kernel has finished booting, as the hypervisor might assume some devices being fully initialized.
+	Snapshot(&'a mut SnapshotParams),
 }
 impl<'a> Hypercall<'a> {
 	/// Get a hypercall's port address.

--- a/uhyve-interface/src/v2/mod.rs
+++ b/uhyve-interface/src/v2/mod.rs
@@ -5,6 +5,9 @@
 //! - The guest writes (or reads) to the respective [`HypercallAddress`](v2::HypercallAddress). The 64-bit value written to that location is the guest's physical memory address of the hypercall's parameter.
 //! - The hypervisor handles the hypercall. Depending on the Hypercall, the hypervisor might change the parameters struct in the guest's memory.
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub mod parameters;
 use parameters::*;
 
@@ -15,6 +18,7 @@ use parameters::*;
 #[non_exhaustive]
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, num_enum::TryFromPrimitive, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HypercallAddress {
 	Exit = 0x1010,
 	SerialWriteByte = 0x1020,

--- a/uhyve-interface/src/v2/parameters.rs
+++ b/uhyve-interface/src/v2/parameters.rs
@@ -237,3 +237,27 @@ pub struct FstatParams {
 	/// Return value of the hypercall.
 	pub ret: StatResult,
 }
+
+/// Parameters for a [`Snapshot`](crate::v2::Hypercall::Snapshot) hypercall.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SnapshotParams {
+	/// Is true, if the snapshot was restored. False if we continue execution.
+	pub restored: bool,
+	/// New HERMIT_IP to use. Only used if `restored` is true.
+	pub new_hermit_ip: Option<[u8; 256]>,
+	/// Memory address of new arguments.
+	pub new_args: GuestPhysAddr,
+	/// Length of new_args in bytes. The hypervisor will update this value to the actual length of the new arguments. Is 0 if no new arguments are provided.
+	pub new_args_len: u64,
+}
+impl Default for SnapshotParams {
+	fn default() -> Self {
+		Self {
+			restored: false,
+			new_hermit_ip: None,
+			new_args: GuestPhysAddr::zero(),
+			new_args_len: 0,
+		}
+	}
+}


### PR DESCRIPTION
Preparation for #1465

The serde support is required to serialize/deserialize the `Stats` structure.