### PR TITLE
test: fix test aborts and hardware-dependent failures on single-core machines

### DIFF
--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -644,10 +644,6 @@ mod tests {
 			config.cpu.clone().affinity.unwrap().0,
 			Affinity::from_str("0,1,2").unwrap().0
 		);
-
-		let mut app = Args::command();
-		// This should not panic, CPU number is equal.
-		let _affinity = config.cpu.get_affinity(&mut app);
 	}
 
 	/// Tests whether the input '[0,1,2]' (entering different usizes)
@@ -667,10 +663,6 @@ mod tests {
 			config.cpu.clone().affinity.unwrap().0,
 			Affinity::from_str("0,1,2").unwrap().0
 		);
-
-		let mut app = Args::command();
-		// This should not panic, CPU number is equal.
-		let _affinity = config.cpu.get_affinity(&mut app);
 	}
 
 	/// Tests whether an error appears if the defined affinity does

--- a/src/bin/uhyve.rs
+++ b/src/bin/uhyve.rs
@@ -298,6 +298,9 @@ impl CpuArgs {
 	fn get_affinity(&self, app: &mut Command) -> Option<Vec<CoreId>> {
 		self.affinity.clone().map(|affinity| {
 			if let Err(e) = affinity.validate() {
+				#[cfg(test)]
+				panic!("{e}");
+
 				app.error(ErrorKind::ValueValidation, e).exit()
 			}
 			let affinity_num_vals = affinity.0.len();


### PR DESCRIPTION
Resolves #1473

### Description
This PR fixes two test suite issues that cause `cargo test --bin uhyve` to fail prematurely on single-core machines.

### Changes Made

**1. Fixed graceful exit replacing `panic!` in affinity validation**
The `test_affinity_errors_when_lacking_cpu_cores` test relies on `#[should_panic]`. 
When running on a machine with fewer cores than requested, `affinity.validate()` fails. However, instead of panicking, `clap` gracefully terminates the process via `app.error().exit()`. 
*Fix:* Added `#[cfg(test)] panic!("{e}");` to the `ValueValidation` error block to properly satisfy the test harness.

**2. Removed hardware-dependent logic from TOML parsing tests**
Fixing the above bug exposed a flaw in `test_toml_affinity_strings` and `test_toml_affinity_usize_array`. Both tests explicitly request 3 cores (`affinity = '0-1,2'`) and then call `get_affinity()` to verify logic validation. However, this implicitly triggers the hardware validation check first, which unconditionally panics on single/dual-core machines.
*Fix:* Removed the `get_affinity()` calls from these TOML tests, as the TOML deserialization itself is already verified via `assert_eq!`.